### PR TITLE
fix(hook): prevent initial data flashing, rename `optimisticState` to `optimisticData`

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -15,7 +15,7 @@ import type { ClientCaller } from ".";
 /**
  * Type of `res` object returned by `useAction` and `useOptimisticAction` hooks.
  */
-export type HookRes<IV extends z.ZodTypeAny, AO> = Awaited<ReturnType<ClientCaller<IV, AO>>> & {
+export type HookRes<IV extends z.ZodTypeAny, Data> = Awaited<ReturnType<ClientCaller<IV, Data>>> & {
 	fetchError?: unknown;
 };
 
@@ -23,14 +23,17 @@ export type HookRes<IV extends z.ZodTypeAny, AO> = Awaited<ReturnType<ClientCall
  * Type of hooks callbacks (`onSuccess` and `onError`).
  * These are executed when the action succeeds or fails.
  */
-export type HookCallbacks<IV extends z.ZodTypeAny, AO> = {
-	onSuccess?: (data: NonNullable<Pick<HookRes<IV, AO>, "data">["data"]>, reset: () => void) => void;
-	onError?: (error: Omit<HookRes<IV, AO>, "data">, reset: () => void) => void;
+export type HookCallbacks<IV extends z.ZodTypeAny, Data> = {
+	onSuccess?: (
+		data: NonNullable<Pick<HookRes<IV, Data>, "data">["data"]>,
+		reset: () => void
+	) => void;
+	onError?: (error: Omit<HookRes<IV, Data>, "data">, reset: () => void) => void;
 };
 
 // ********************* FUNCTIONS *********************
 
-const getActionStatus = <IV extends z.ZodTypeAny, AO>(res: HookRes<IV, AO>) => {
+const getActionStatus = <const IV extends z.ZodTypeAny, const Data>(res: HookRes<IV, Data>) => {
 	const hasSucceded = typeof res.data !== "undefined";
 	const hasErrored =
 		typeof res.validationError !== "undefined" ||
@@ -42,12 +45,12 @@ const getActionStatus = <IV extends z.ZodTypeAny, AO>(res: HookRes<IV, AO>) => {
 	return { hasExecuted, hasSucceded, hasErrored };
 };
 
-const useActionCallbacks = <const IV extends z.ZodTypeAny, const AO>(
-	res: HookRes<IV, AO>,
+const useActionCallbacks = <const IV extends z.ZodTypeAny, const Data>(
+	res: HookRes<IV, Data>,
 	hasSucceded: boolean,
 	hasErrored: boolean,
 	reset: () => void,
-	cb?: HookCallbacks<IV, AO>
+	cb?: HookCallbacks<IV, Data>
 ) => {
 	const onSuccessRef = useRef(cb?.onSuccess);
 	const onErrorRef = useRef(cb?.onError);
@@ -72,15 +75,15 @@ const useActionCallbacks = <const IV extends z.ZodTypeAny, const AO>(
  *
  * {@link https://github.com/theedoran/next-safe-action#2-the-hook-way See an example}
  */
-export const useAction = <const IV extends z.ZodTypeAny, const AO>(
-	clientCaller: ClientCaller<IV, AO>,
-	cb?: HookCallbacks<IV, AO>
+export const useAction = <const IV extends z.ZodTypeAny, const Data>(
+	clientCaller: ClientCaller<IV, Data>,
+	cb?: HookCallbacks<IV, Data>
 ) => {
 	const [isExecuting, startTransition] = useTransition();
 	const executor = useRef(clientCaller);
-	const [res, setRes] = useState<HookRes<IV, AO>>({});
+	const [res, setRes] = useState<HookRes<IV, Data>>({});
 
-	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, AO>(res);
+	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, Data>(res);
 
 	const execute = useCallback(async (input: z.input<IV>) => {
 		startTransition(() => {
@@ -120,10 +123,14 @@ export const useAction = <const IV extends z.ZodTypeAny, const AO>(
  *
  * {@link https://github.com/theedoran/next-safe-action#optimistic-update--experimental See an example}
  */
-export const useOptimisticAction = <const IV extends z.ZodTypeAny, const AO, State extends object>(
-	clientCaller: ClientCaller<IV, AO>,
+export const useOptimisticAction = <
+	const IV extends z.ZodTypeAny,
+	const Data,
+	State extends object
+>(
+	clientCaller: ClientCaller<IV, Data>,
 	defaultOptState: State,
-	cb?: HookCallbacks<IV, AO>
+	cb?: HookCallbacks<IV, Data>
 ) => {
 	const [optState, syncState] = experimental_useOptimistic<
 		State & { __isExecuting__: boolean },
@@ -135,9 +142,9 @@ export const useOptimisticAction = <const IV extends z.ZodTypeAny, const AO, Sta
 	}));
 
 	const executor = useRef(clientCaller);
-	const [res, setRes] = useState<HookRes<IV, AO>>({});
+	const [res, setRes] = useState<HookRes<IV, Data>>({});
 
-	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, AO>(res);
+	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, Data>(res);
 
 	const execute = useCallback(
 		(input: z.input<IV>, newServerState: Partial<State>) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import type { z } from "zod";
 /**
  * Type of the function called from Client Components with typesafe input data for the Server Action.
  */
-export type ClientCaller<IV extends z.ZodTypeAny, AO> = (input: z.input<IV>) => Promise<{
-	data?: AO;
+export type ClientCaller<IV extends z.ZodTypeAny, Data> = (input: z.input<IV>) => Promise<{
+	data?: Data;
 	serverError?: true;
 	validationError?: Partial<Record<keyof z.input<IV>, string[]>>;
 }>;
@@ -23,21 +23,21 @@ export type ClientCaller<IV extends z.ZodTypeAny, AO> = (input: z.input<IV>) => 
  * {@link https://github.com/theedoran/next-safe-action#authenticated-action See an example}.
  */
 export type ActionOverload<AuthData extends object> = {
-	<const IV extends z.ZodTypeAny, const AO>(
+	<const IV extends z.ZodTypeAny, const Data>(
 		opts: {
 			input: IV;
 			withAuth?: false;
 		},
-		actionDefinition: (parsedInput: z.input<IV>, authData: undefined) => Promise<AO>
-	): ClientCaller<IV, AO>;
+		actionDefinition: (parsedInput: z.input<IV>, authData: undefined) => Promise<Data>
+	): ClientCaller<IV, Data>;
 
-	<const IV extends z.ZodTypeAny, const AO>(
+	<const IV extends z.ZodTypeAny, const Data>(
 		opts: {
 			input: IV;
 			withAuth: true;
 		},
-		actionDefinition: (parsedInput: z.input<IV>, authData: AuthData) => Promise<AO>
-	): ClientCaller<IV, AO>;
+		actionDefinition: (parsedInput: z.input<IV>, authData: AuthData) => Promise<Data>
+	): ClientCaller<IV, Data>;
 };
 
 // ********************* FUNCTIONS *********************


### PR DESCRIPTION
After calling `revalidatePath`, Next.js refreshes CSS via browser request. During this time interval, the initial state passed to `useOptimisticAction` hook is flashed. This PR forces the optimistic state type to be the same as `res.data` (action's return type), spreads the `res.data` object after `initialOptData`,  and renames `optimisticState` to `optimisticData`, which is less confusing, since types now match.

Closes #10  