### PR TITLE
feat(hooks): add input parameter to callbacks

### DIFF
--- a/packages/example-app/src/app/hook/deleteuser-form.tsx
+++ b/packages/example-app/src/app/hook/deleteuser-form.tsx
@@ -20,14 +20,14 @@ const DeleteUserForm = ({ userId, deleteUser }: Props) => {
 		hasErrored,
 		reset,
 	} = useAction(deleteUser, {
-		onSuccess(data, reset) {
-			console.log("HELLO FROM ONSUCCESS", data);
+		onSuccess(data, reset, input) {
+			console.log("HELLO FROM ONSUCCESS", data, input);
 
 			// You can reset response object by calling `reset`.
 			// reset();
 		},
-		onError(error, reset) {
-			console.log("OH NO FROM ONERROR", error);
+		onError(error, reset, input) {
+			console.log("OH NO FROM ONERROR", error, input);
 
 			// You can reset response object by calling `reset`.
 			// reset();

--- a/packages/example-app/src/app/optimistic-hook/addlikes-form.tsx
+++ b/packages/example-app/src/app/optimistic-hook/addlikes-form.tsx
@@ -23,14 +23,14 @@ const AddLikesForm = ({ likesCount, addLikes }: Props) => {
 		addLikes,
 		{ likesCount },
 		{
-			onSuccess(data, reset) {
-				console.log("HELLO FROM ONSUCCESS", data);
+			onSuccess(data, reset, input) {
+				console.log("HELLO FROM ONSUCCESS", data, input);
 
 				// You can reset response object by calling `reset`.
 				// reset();
 			},
-			onError(error, reset) {
-				console.log("OH NO FROM ONERROR", error);
+			onError(error, reset, input) {
+				console.log("OH NO FROM ONERROR", error, input);
 
 				// You can reset response object by calling `reset`.
 				// reset();
@@ -79,7 +79,7 @@ const AddLikesForm = ({ likesCount, addLikes }: Props) => {
 			</form>
 			<div id="response-container">
 				{/* This object will update immediately when you execute the action.
-            Real data will come back once action has finished executing. */}
+						Real data will come back once action has finished executing. */}
 				<pre>Optimistic data: {JSON.stringify(optimisticData)}</pre>{" "}
 				<pre>Is executing: {JSON.stringify(isExecuting)}</pre>
 				<div>Action response:</div>

--- a/packages/next-safe-action/README.md
+++ b/packages/next-safe-action/README.md
@@ -1,6 +1,6 @@
 # [next-safe-action](https://github.com/TheEdoRan/next-safe-action)
 
-> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components. 
+> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components.
 
 This is the new documentation, for version 3 of the library. If you want to check out the old documentation, [you can find it here](README_v2.md).
 
@@ -9,7 +9,7 @@ This is the new documentation, for version 3 of the library. If you want to chec
 - ✅ End to end type safety
 - ✅ Context based clients
 - ✅ Input validation
-- ✅ Direct or hook usage from client  
+- ✅ Direct or hook usage from client
 - ✅ Optimistic updates
 
 
@@ -199,19 +199,25 @@ export default function Login({ loginUser }: Props) {
     hasErrored,
     reset,
   } = useAction(loginUser, {
-      onSuccess: (data, reset) => {
+      onSuccess: (data, reset, input) => {
         // Data from server action.
         const { failure, success } = data;
 
         // Reset response object.
         reset();
+
+        // Data used to call `execute`.
+        const { username, password } = input;
       },
-      onError: (error, reset) => {
+      onError: (error, reset, input) => {
         // One of these errors.
         const { fetchError, serverError, validationError } = error;
 
         // Reset response object.
         reset();
+
+        // Data used to call `execute`.
+        const { username, password } = input;
       },
     }
   );
@@ -241,7 +247,7 @@ export default function Login({ loginUser }: Props) {
 
 The `useAction` has one required argument (the action) and one optional argument (an object with `onSuccess` and `onError` callbacks).
 
-`onSuccess(data, reset)` and `onError(error, reset)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback).
+`onSuccess(data, reset, input)` and `onError(error, reset, input)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback). The original payload of the action is available as the third argument of the callback (`input`): this is the same data that was passed to the `execute` function.
 
 It returns an object with seven keys:
 
@@ -319,8 +325,8 @@ export default function AddLikes({ likesCount, addLikes }: Props) {
     addLikes,
     { likesCount }, // [1]
     {
-      onSuccess: (data, reset) => {},
-      onError: (error, reset) => {},
+      onSuccess: (data, reset, input) => {},
+      onError: (error, reset, input) => {},
     }
   );
 

--- a/packages/next-safe-action/README_v2.md
+++ b/packages/next-safe-action/README_v2.md
@@ -1,6 +1,6 @@
 # [next-safe-action](https://github.com/TheEdoRan/next-safe-action)
 
-> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components.
+> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components. 
 
 This is the old documentation, for version 2 of the library. If you want to check out the new documentation, [you can find it here](README.md).
 
@@ -8,7 +8,7 @@ This is the old documentation, for version 2 of the library. If you want to chec
 - ✅ Pretty simple
 - ✅ End to end type safety
 - ✅ Input validation
-- ✅ Direct or hook usage from client
+- ✅ Direct or hook usage from client  
 - ✅ Optimistic updates
 - ✅ Authenticated actions
 
@@ -201,9 +201,6 @@ export default function Login({ loginUser }: Props) {
 
         // Reset response object.
         reset();
-
-        // Data used to call `execute`.
-        const { username, password } = input;
       },
       onError: (error, reset) => {
         // One of these errors.
@@ -211,9 +208,6 @@ export default function Login({ loginUser }: Props) {
 
         // Reset response object.
         reset();
-
-        // Data used to call `execute`.
-        const { username, password } = input;
       },
     }
   );
@@ -243,7 +237,7 @@ export default function Login({ loginUser }: Props) {
 
 The `useAction` has one required argument (the action) and one optional argument (an object with `onSuccess` and `onError` callbacks).
 
-`onSuccess(data, reset)` and `onError(error, reset)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback). The original payload of the action is available as the third argument of the callback (`input`): this is the same data that was passed to the `execute` function.
+`onSuccess(data, reset)` and `onError(error, reset)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback).
 
 It returns an object with seven keys:
 
@@ -323,8 +317,8 @@ export default function AddLikes({ likesCount, addLikes }: Props) {
     addLikes,
     { likesCount }, // [1]
     {
-      onSuccess: (data, reset, input) => {},
-      onError: (error, reset, input) => {},
+      onSuccess: (data, reset) => {},
+      onError: (error, reset) => {},
     }
   );
 

--- a/packages/next-safe-action/README_v2.md
+++ b/packages/next-safe-action/README_v2.md
@@ -1,6 +1,6 @@
 # [next-safe-action](https://github.com/TheEdoRan/next-safe-action)
 
-> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components. 
+> `next-safe-action` is a library that takes full advantage of the latest and greatest Next.js, React and TypeScript features, using Zod, to let you define typesafe actions on the server and call them from Client Components.
 
 This is the old documentation, for version 2 of the library. If you want to check out the new documentation, [you can find it here](README.md).
 
@@ -8,7 +8,7 @@ This is the old documentation, for version 2 of the library. If you want to chec
 - ✅ Pretty simple
 - ✅ End to end type safety
 - ✅ Input validation
-- ✅ Direct or hook usage from client  
+- ✅ Direct or hook usage from client
 - ✅ Optimistic updates
 - ✅ Authenticated actions
 
@@ -201,6 +201,9 @@ export default function Login({ loginUser }: Props) {
 
         // Reset response object.
         reset();
+
+        // Data used to call `execute`.
+        const { username, password } = input;
       },
       onError: (error, reset) => {
         // One of these errors.
@@ -208,6 +211,9 @@ export default function Login({ loginUser }: Props) {
 
         // Reset response object.
         reset();
+
+        // Data used to call `execute`.
+        const { username, password } = input;
       },
     }
   );
@@ -237,7 +243,7 @@ export default function Login({ loginUser }: Props) {
 
 The `useAction` has one required argument (the action) and one optional argument (an object with `onSuccess` and `onError` callbacks).
 
-`onSuccess(data, reset)` and `onError(error, reset)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback).
+`onSuccess(data, reset)` and `onError(error, reset)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback). The original payload of the action is available as the third argument of the callback (`input`): this is the same data that was passed to the `execute` function.
 
 It returns an object with seven keys:
 
@@ -317,8 +323,8 @@ export default function AddLikes({ likesCount, addLikes }: Props) {
     addLikes,
     { likesCount }, // [1]
     {
-      onSuccess: (data, reset) => {},
-      onError: (error, reset) => {},
+      onSuccess: (data, reset, input) => {},
+      onError: (error, reset, input) => {},
     }
   );
 

--- a/packages/next-safe-action/src/types.ts
+++ b/packages/next-safe-action/src/types.ts
@@ -35,7 +35,8 @@ export type HookRes<IV extends z.ZodTypeAny, Data> = Awaited<ReturnType<ClientCa
 export type HookCallbacks<IV extends z.ZodTypeAny, Data> = {
 	onSuccess?: (
 		data: NonNullable<Pick<HookRes<IV, Data>, "data">["data"]>,
-		reset: () => void
+		reset: () => void,
+		input: z.input<IV>
 	) => void;
-	onError?: (error: Omit<HookRes<IV, Data>, "data">, reset: () => void) => void;
+	onError?: (error: Omit<HookRes<IV, Data>, "data">, reset: () => void, input: z.input<IV>) => void;
 };


### PR DESCRIPTION
Hi Edoardo!
First of all, thanks a lot for this library, it's super handy when working with server actions :+1: 

I've opened a PR to add another parameter to the `onSuccess` and `onError` callbacks, which contains the original input as it's sent to the server. This is handy whenever the server is not returning all the expected data, or the error callback is called, but the client still needs the input data to do something (for instance, render a toast containing a message).

Example:

```ts
const { execute } = useAction(
  sendEmail,
  {
    onError: (_, _, input) => {
      toast({
        title: `Error while sending an email to: ${input.email}`,
      });
    },
  },
);

const handleSendEmal = (email: string) => {
  execute({ email: email });
};
```

Without the `input` parameter, there is no way for me to get access to the payload that was sent to the server unless I add a state to my component to keep track of it, which is far less convenient then the solution above.

This idea can also be found in libraries like [TanStack Query](https://tanstack.com/query/v4/docs/react/reference/useMutation) where they have this argument called `variables` on their callbacks which I believe is basically the same thing.

Please let me know what you think :relaxed: 