### PR TITLE
Add onExecute callback

### DIFF
--- a/packages/example-app/src/app/hook/deleteuser-form.tsx
+++ b/packages/example-app/src/app/hook/deleteuser-form.tsx
@@ -32,6 +32,9 @@ const DeleteUserForm = ({ userId, deleteUser }: Props) => {
 			// You can reset response object by calling `reset`.
 			// reset();
 		},
+		onExecute(input) {
+			console.log("HELLO FROM ONEXECUTE", input);
+		},
 	});
 
 	console.log(

--- a/packages/example-app/src/app/optimistic-hook/addlikes-form.tsx
+++ b/packages/example-app/src/app/optimistic-hook/addlikes-form.tsx
@@ -35,6 +35,9 @@ const AddLikesForm = ({ likesCount, addLikes }: Props) => {
 				// You can reset response object by calling `reset`.
 				// reset();
 			},
+			onExecute(input) {
+				console.log("HELLO FROM ONEXECUTE", input);
+			},
 		}
 	);
 

--- a/packages/next-safe-action/README.md
+++ b/packages/next-safe-action/README.md
@@ -188,7 +188,7 @@ type Props = {
 };
 
 export default function Login({ loginUser }: Props) {
-  // Safe action (`loginUser`) and optional `onSuccess` and `onError` callbacks
+  // Safe action (`loginUser`) and optional `onSuccess`, `onError` and `onExecute` callbacks
   // passed to `useAction` hook.
   const {
     execute,
@@ -219,6 +219,10 @@ export default function Login({ loginUser }: Props) {
         // Data used to call `execute`.
         const { username, password } = input;
       },
+      onExecute: (input) => {
+        // Action input.
+        const { username, password } = input;
+      },
     }
   );
 
@@ -245,9 +249,10 @@ export default function Login({ loginUser }: Props) {
 }
 ```
 
-The `useAction` has one required argument (the action) and one optional argument (an object with `onSuccess` and `onError` callbacks).
+The `useAction` has one required argument (the action) and one optional argument (an object with `onSuccess`, `onError` and `onExecute` callbacks).
 
 `onSuccess(data, reset, input)` and `onError(error, reset, input)` are executed, respectively, when the action executes successfully or fails. You can reset the response object inside these callbacks with `reset()` (second argument of the callback). The original payload of the action is available as the third argument of the callback (`input`): this is the same data that was passed to the `execute` function.
+`onExecute(input)` is executed when the action is called from the client, regardless of the result.
 
 It returns an object with seven keys:
 
@@ -330,6 +335,7 @@ export default function AddLikes({ likesCount, addLikes }: Props) {
     {
       onSuccess: (data, reset, input) => {},
       onError: (error, reset, input) => {},
+      onExecute: (input) => {},
     }
   );
 

--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -137,6 +137,7 @@ export const useOptimisticAction = <const IV extends z.ZodTypeAny, const Data>(
 	}));
 
 	const executor = useRef(clientCaller);
+	const onExecuteRef = useRef(cb?.onExecute);
 
 	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, Data>(res);
 
@@ -144,6 +145,11 @@ export const useOptimisticAction = <const IV extends z.ZodTypeAny, const Data>(
 		(input: z.input<IV>, newOptimisticData: Partial<Data>) => {
 			syncState(newOptimisticData);
 			setInput(input);
+
+			const onExecute = onExecuteRef.current;
+			if (onExecute) {
+				onExecute(input);
+			}
 
 			return executor
 				.current(input)

--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -66,11 +66,17 @@ export const useAction = <const IV extends z.ZodTypeAny, const Data>(
 	const executor = useRef(clientCaller);
 	const [res, setRes] = useState<HookRes<IV, Data>>({});
 	const [input, setInput] = useState<z.input<IV>>();
+	const onExecuteRef = useRef(cb?.onExecute);
 
 	const { hasExecuted, hasSucceded, hasErrored } = getActionStatus<IV, Data>(res);
 
 	const execute = useCallback((input: z.input<IV>) => {
 		setInput(input);
+
+		const onExecute = onExecuteRef.current;
+		if (onExecute) {
+			onExecute(input);
+		}
 
 		return startTransition(() => {
 			return executor

--- a/packages/next-safe-action/src/types.ts
+++ b/packages/next-safe-action/src/types.ts
@@ -39,6 +39,7 @@ export type HookCallbacks<IV extends z.ZodTypeAny, Data> = {
 		input: z.input<IV>
 	) => void;
 	onError?: (error: Omit<HookRes<IV, Data>, "data">, reset: () => void, input: z.input<IV>) => void;
+	onExecute?: (input: z.input<IV>) => unknown;
 };
 
 export type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
## Purpose
Inspired by [react-query](https://tanstack.com/query/latest/docs/react/overview)'s `onMutate` I added the callback `onExecute` to both hooks `useAction` and `useOptimisticAction`. This callback is useful to run code before any action and avoid creating an extra helper function. The input can be accessed aswell in order to perform different actions based on it

**Before**

```typescript
const action = useAction(myAction)

const mutate = () => {
    console.log("I really want to print this on action execution");
    action.execute();
}

return <button onClick={mutate}>hello</button>
```

**After**

```typescript
const action = useAction(myAction, {
    onExecute(input) {
        console.log("I really want to print this on action execution", input);
    }
})

return <button onClick={action.execute}>hello</button>
```