### PR TITLE
fix(hooks): fix handling Next redirects and 404s

### DIFF
--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -104,7 +104,7 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 		setInput(input);
 
 		return startTransition(() => {
-			executor
+			return executor
 				.current(input)
 				.then((res) => setResult(res ?? DEFAULT_RESULT))
 				.catch((e) => {
@@ -114,11 +114,15 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 
 					setResult({ fetchError: e });
 				})
-				.finally(() => setIsExecuting(false));
+				.finally(() => {
+					setIsExecuting(false);
+				});
 		});
 	}, []);
 
-	const reset = useCallback(() => setResult(DEFAULT_RESULT), []);
+	const reset = useCallback(() => {
+		setResult(DEFAULT_RESULT);
+	}, []);
 
 	useActionCallbacks(result, input, status, reset, callbacks);
 
@@ -166,23 +170,26 @@ export const useOptimisticAction = <const Schema extends z.ZodTypeAny, const Dat
 			setOptimisticState(input);
 			setInput(input);
 
-			executor
+			return executor
 				.current(input)
 				.then((res) => setResult(res ?? DEFAULT_RESULT))
 				.catch((e) => {
-					// NOTE: this doesn't work at the moment.
 					if (isNextRedirectError(e) || isNextNotFoundError(e)) {
 						throw e;
 					}
 
 					setResult({ fetchError: e });
 				})
-				.finally(() => setIsExecuting(false));
+				.finally(() => {
+					setIsExecuting(false);
+				});
 		},
 		[setOptimisticState]
 	);
 
-	const reset = useCallback(() => setResult(DEFAULT_RESULT), []);
+	const reset = useCallback(() => {
+		setResult(DEFAULT_RESULT);
+	}, []);
 
 	useActionCallbacks(result, input, status, reset, callbacks);
 

--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -85,7 +85,7 @@ const useActionCallbacks = <const Schema extends z.ZodTypeAny, const Data>(
  * @param safeAction The typesafe action.
  * @param callbacks Optional callbacks executed when the action succeeds or fails.
  *
- * {@link https://github.com/TheEdoRan/next-safe-action/tree/main/packages/next-safe-action#2-the-hook-way See an example}
+ * {@link https://next-safe-action.dev/docs/usage-from-client/hooks/useaction See an example}
  */
 export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 	safeAction: SafeAction<Schema, Data>,
@@ -142,7 +142,7 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
  * @param initialOptimisticData Initial optimistic data.
  * @param callbacks Optional callbacks executed when the action succeeds or fails.
  *
- * {@link https://github.com/TheEdoRan/next-safe-action/tree/main/packages/next-safe-action#optimistic-update--experimental See an example}
+ * {@link https://next-safe-action.dev/docs/usage-from-client/hooks/useoptimisticaction See an example}
  */
 export const useOptimisticAction = <const Schema extends z.ZodTypeAny, const Data>(
 	safeAction: SafeAction<Schema, Data>,

--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -103,10 +103,10 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 		setIsExecuting(true);
 		setInput(input);
 
-		return startTransition(() =>
+		return startTransition(() => {
 			executor
 				.current(input)
-				.then((res) => (res ? setResult(res) : void 0))
+				.then((res) => setResult(res ?? DEFAULT_RESULT))
 				.catch((e) => {
 					if (isNextRedirectError(e) || isNextNotFoundError(e)) {
 						throw e;
@@ -114,8 +114,8 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 
 					setResult({ fetchError: e });
 				})
-				.finally(() => setIsExecuting(false))
-		);
+				.finally(() => setIsExecuting(false));
+		});
 	}, []);
 
 	const reset = useCallback(() => setResult(DEFAULT_RESULT), []);
@@ -168,9 +168,9 @@ export const useOptimisticAction = <const Schema extends z.ZodTypeAny, const Dat
 
 			executor
 				.current(input)
-				.then((res) => (res ? setResult(res) : void 0))
+				.then((res) => setResult(res ?? DEFAULT_RESULT))
 				.catch((e) => {
-					// TODO: this doesn't work at the moment.
+					// NOTE: this doesn't work at the moment.
 					if (isNextRedirectError(e) || isNextNotFoundError(e)) {
 						throw e;
 					}

--- a/packages/next-safe-action/src/hook.ts
+++ b/packages/next-safe-action/src/hook.ts
@@ -11,7 +11,7 @@ import {
 import {} from "react/experimental";
 import type { z } from "zod";
 import type { HookActionStatus, HookCallbacks, HookResult, SafeAction } from "./types";
-import { isNextNotFoundError, isNextRedirectError } from "./utils";
+import { isError, isNextNotFoundError, isNextRedirectError } from "./utils";
 
 // UTILS
 
@@ -112,7 +112,7 @@ export const useAction = <const Schema extends z.ZodTypeAny, const Data>(
 						throw e;
 					}
 
-					setResult({ fetchError: e });
+					setResult({ fetchError: isError(e) ? e.message : "Something went wrong" });
 				})
 				.finally(() => {
 					setIsExecuting(false);
@@ -178,7 +178,7 @@ export const useOptimisticAction = <const Schema extends z.ZodTypeAny, const Dat
 						throw e;
 					}
 
-					setResult({ fetchError: e });
+					setResult({ fetchError: isError(e) ? e.message : "Something went wrong" });
 				})
 				.finally(() => {
 					setIsExecuting(false);

--- a/packages/next-safe-action/src/server.ts
+++ b/packages/next-safe-action/src/server.ts
@@ -71,9 +71,9 @@ export const createSafeActionClient = <Context>(createOpts?: {
 					return { serverError: DEFAULT_SERVER_ERROR };
 				}
 
-				await Promise.resolve(handleServerErrorLog(e as Error));
+				await Promise.resolve(handleServerErrorLog(e));
 
-				return await Promise.resolve(handleReturnedServerError(e as Error));
+				return await Promise.resolve(handleReturnedServerError(e));
 			}
 		};
 	};

--- a/packages/next-safe-action/src/server.ts
+++ b/packages/next-safe-action/src/server.ts
@@ -7,7 +7,7 @@ import { DEFAULT_SERVER_ERROR, isError, isNextNotFoundError, isNextRedirectError
  * @param createOpts Options for creating a new action client.
  * @returns {Function} A function that creates a new action, to be used in server files.
  *
- * {@link https://github.com/TheEdoRan/next-safe-action/tree/main/packages/next-safe-action#project-configuration See an example}
+ * {@link https://next-safe-action.dev/docs/getting-started See an example}
  */
 export const createSafeActionClient = <Context>(createOpts?: {
 	handleServerErrorLog?: (e: Error) => MaybePromise<void>;

--- a/packages/next-safe-action/src/types.ts
+++ b/packages/next-safe-action/src/types.ts
@@ -27,7 +27,7 @@ export type ServerCode<Schema extends z.ZodTypeAny, Data, Context> = (
 export type HookResult<Schema extends z.ZodTypeAny, Data> = Awaited<
 	ReturnType<SafeAction<Schema, Data>>
 > & {
-	fetchError?: unknown;
+	fetchError?: string;
 };
 
 /**

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,4 +1,24 @@
-export const isError = (e: any) => e instanceof Error;
-export const isNextRedirectError = (e: any) => isError(e) && e.message === "NEXT_REDIRECT";
-export const isNextNotFoundError = (e: any) => isError(e) && e.message === "NEXT_NOT_FOUND";
+import type { RedirectError } from "next/dist/client/components/redirect";
+
 export const DEFAULT_SERVER_ERROR = "Something went wrong while executing the operation";
+
+const REDIRECT_ERROR_CODE = "NEXT_REDIRECT";
+const NOT_FOUND_ERROR_CODE = "NEXT_NOT_FOUND";
+
+export const isNextRedirectError = <U extends string>(error: any): error is RedirectError<U> => {
+	if (typeof (error == null ? void 0 : error.digest) !== "string") return false;
+	const [errorCode, type, destination, permanent] = error.digest.split(";", 4);
+	return (
+		errorCode === REDIRECT_ERROR_CODE &&
+		(type === "replace" || type === "push") &&
+		typeof destination === "string" &&
+		(permanent === "true" || permanent === "false")
+	);
+};
+
+type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE };
+
+export const isNextNotFoundError = (error: any): error is NotFoundError =>
+	(error == null ? void 0 : error.digest) === NOT_FOUND_ERROR_CODE;
+
+export const isError = (error: any): error is Error => error instanceof Error;

--- a/packages/website/docs/types.md
+++ b/packages/website/docs/types.md
@@ -32,11 +32,13 @@ type ServerCode<Schema extends z.ZodTypeAny, Data, Context> = (
 
 Type of `result` object returned by `useAction` and `useOptimisticAction` hooks.
 
+If a server-client communication error occurs, `fetchError` will be set to the error message.
+
 ```typescript
 type HookResult<Schema extends z.ZodTypeAny, Data> = Awaited<
   ReturnType<SafeAction<Schema, Data>>
 > & {
-  fetchError?: unknown;
+  fetchError?: string;
 };
 ```
 

--- a/packages/website/docs/usage-from-client/hooks/callbacks.md
+++ b/packages/website/docs/usage-from-client/hooks/callbacks.md
@@ -16,7 +16,7 @@ const action = useAction(testAction, {
 });
 ```
 
-Here is the full list of callbacks, with their behavior explained. All of thme are optional and have return type `void` or `Promise<void>` (normal or async functions with no return):
+Here is the full list of callbacks, with their behavior explained. All of them are optional and have return type `void` or `Promise<void>` (async or non-async functions with no return):
 
 | Name         | [`HookActionStatus`](/docs/types#hookactionstatus) state               | Arguments                                                                                                |
 |--------------|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
- Update the `isNextRedirectError` and `isNextNotFoundError` methods to be identical to the Next.js internals.
- Update the `useAction` and `useOptimisticAction` hooks to use a default result state and not set an undefined result, as can happen when handling the `NEXT_REDIRECT` or `NEXT_NOT_FOUND` responses.