### PR TITLE
feat(servervalidationerror): adds a ServerValidationError

### DIFF
--- a/packages/example-app/src/app/login-action.ts
+++ b/packages/example-app/src/app/login-action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { action } from "@/lib/safe-action";
+import { returnValidationErrors } from "next-safe-action";
 import { z } from "zod";
 
 const input = z.object({
@@ -8,11 +9,11 @@ const input = z.object({
 	password: z.string().min(8).max(100),
 });
 
-export const loginUser = action(input, async ({ username, password }, { returnValidationErrors, ctx }) => {
+export const loginUser = action(input, async ({ username, password }, ctx) => {
 	if (username === "johndoe") {
-		returnValidationErrors({
+		returnValidationErrors(input, {
 			username: {
-				_errors: ['user_suspended']
+				_errors: ["user_suspended"],
 			},
 		});
 	}
@@ -23,9 +24,9 @@ export const loginUser = action(input, async ({ username, password }, { returnVa
 		};
 	}
 
-	returnValidationErrors({
+	returnValidationErrors(input, {
 		username: {
-			_errors: ['incorrect_credentials']
+			_errors: ["incorrect_credentials"],
 		},
-    });
+	});
 });

--- a/packages/example-app/src/app/login-action.ts
+++ b/packages/example-app/src/app/login-action.ts
@@ -8,10 +8,12 @@ const input = z.object({
 	password: z.string().min(8).max(100),
 });
 
-export const loginUser = action(input, async ({ username, password }, _ctx, { returnValidationErrors }) => {
+export const loginUser = action(input, async ({ username, password }, { returnValidationErrors, ctx }) => {
 	if (username === "johndoe") {
 		returnValidationErrors({
-			username: ['user_suspended'],
+			username: {
+				_errors: ['user_suspended']
+			},
 		});
 	}
 
@@ -22,6 +24,8 @@ export const loginUser = action(input, async ({ username, password }, _ctx, { re
 	}
 
 	returnValidationErrors({
-		username: ['incorrect_credentials'],
+		username: {
+			_errors: ['incorrect_credentials']
+		},
     });
 });

--- a/packages/example-app/src/app/login-action.ts
+++ b/packages/example-app/src/app/login-action.ts
@@ -8,9 +8,9 @@ const input = z.object({
 	password: z.string().min(8).max(100),
 });
 
-export const loginUser = action(input, async ({ username, password }, _ctx, serverValidationError) => {
+export const loginUser = action(input, async ({ username, password }, _ctx, { throwServerValidationError }) => {
 	if (username === "johndoe") {
-		serverValidationError({
+		throwServerValidationError({
 			username: ['user_suspended'],
 		});
 	}
@@ -21,7 +21,7 @@ export const loginUser = action(input, async ({ username, password }, _ctx, serv
 		};
 	}
 
-	serverValidationError({
+	throwServerValidationError({
 		username: ['incorrect_credentials'],
     });
 });

--- a/packages/example-app/src/app/login-action.ts
+++ b/packages/example-app/src/app/login-action.ts
@@ -8,9 +8,9 @@ const input = z.object({
 	password: z.string().min(8).max(100),
 });
 
-export const loginUser = action(input, async ({ username, password }, _ctx, { throwServerValidationError }) => {
+export const loginUser = action(input, async ({ username, password }, _ctx, { returnValidationErrors }) => {
 	if (username === "johndoe") {
-		throwServerValidationError({
+		returnValidationErrors({
 			username: ['user_suspended'],
 		});
 	}
@@ -21,7 +21,7 @@ export const loginUser = action(input, async ({ username, password }, _ctx, { th
 		};
 	}
 
-	throwServerValidationError({
+	returnValidationErrors({
 		username: ['incorrect_credentials'],
     });
 });

--- a/packages/example-app/src/app/login-action.ts
+++ b/packages/example-app/src/app/login-action.ts
@@ -8,13 +8,11 @@ const input = z.object({
 	password: z.string().min(8).max(100),
 });
 
-export const loginUser = action(input, async ({ username, password }) => {
+export const loginUser = action(input, async ({ username, password }, _ctx, serverValidationError) => {
 	if (username === "johndoe") {
-		return {
-			error: {
-				reason: "user_suspended",
-			},
-		};
+		serverValidationError({
+			username: ['user_suspended'],
+		});
 	}
 
 	if (username === "user" && password === "password") {
@@ -23,9 +21,7 @@ export const loginUser = action(input, async ({ username, password }) => {
 		};
 	}
 
-	return {
-		error: {
-			reason: "incorrect_credentials",
-		},
-	};
+	serverValidationError({
+		username: ['incorrect_credentials'],
+    });
 });

--- a/packages/example-app/src/app/with-context/edituser-action.ts
+++ b/packages/example-app/src/app/with-context/edituser-action.ts
@@ -13,7 +13,7 @@ export const editUser = authAction(
 	// Here you have access to `userId`, which comes from `buildContext`
 	// return object in src/lib/safe-action.ts.
 	//                          \\\\\
-	async ({ fullName, age }, userId) => {
+	async ({ fullName, age }, { ctx: { userId } }) => {
 		if (fullName.toLowerCase() === "john doe") {
 			return {
 				error: {

--- a/packages/example-app/src/app/with-context/edituser-action.ts
+++ b/packages/example-app/src/app/with-context/edituser-action.ts
@@ -13,7 +13,7 @@ export const editUser = authAction(
 	// Here you have access to `userId`, which comes from `buildContext`
 	// return object in src/lib/safe-action.ts.
 	//                          \\\\\
-	async ({ fullName, age }, { ctx: { userId } }) => {
+	async ({ fullName, age }, { userId }) => {
 		if (fullName.toLowerCase() === "john doe") {
 			return {
 				error: {

--- a/packages/example-app/src/lib/safe-action.ts
+++ b/packages/example-app/src/lib/safe-action.ts
@@ -39,7 +39,7 @@ export const authAction = createSafeActionClient({
 			parsedInput
 		);
 
-		return userId;
+		return { userId };
 	},
 	handleReturnedServerError,
 });

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -27,7 +27,7 @@ export type SafeAction<S extends Schema, Data> = (input: InferIn<S>) => Promise<
 }>;
 
 type Utils<S extends Schema> = {
-	throwServerValidationError: typeof throwServerValidationError<S>
+	returnValidationErrors: typeof throwServerValidationError<S>
 };
 
 /**
@@ -86,7 +86,7 @@ export const createSafeActionClient = <Context>(createOpts?: SafeClientOpts<Cont
 		// Helper function to create ServerValidationError with injected schema
 
 		const utils: Utils<S> = {
-			throwServerValidationError,
+			returnValidationErrors: throwServerValidationError,
 		};
 
 		// This is the function called by client. If `input` fails the schema

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,7 +1,8 @@
 import type { Infer, Schema, ValidationIssue } from "@decs/typeschema";
+import { ServerValidationError } from "./index";
 
 export const isError = (error: any): error is Error => error instanceof Error;
-
+export const isServerValidationError = <S extends Schema>(error: unknown): error is ServerValidationError<S> => error instanceof ServerValidationError;
 // UTIL TYPES
 
 // Returns type or promise of type.

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,8 +1,7 @@
 import type { Infer, Schema, ValidationIssue } from "@decs/typeschema";
-import { ServerValidationError } from "./index";
 
 export const isError = (error: unknown): error is Error => error instanceof Error;
-export const isServerValidationError = <S extends Schema>(error: unknown): error is ServerValidationError<S> => error instanceof ServerValidationError;
+
 // UTIL TYPES
 
 // Returns type or promise of type.
@@ -63,7 +62,3 @@ export const buildValidationErrors = <const S extends Schema>(issues: Validation
 
 	return ve as ValidationErrors<S>;
 };
-
-export const throwServerValidationError = <S extends Schema>(validationErrors: ValidationErrors<S>): never => {
-	throw new ServerValidationError<S>(validationErrors);
-}

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Infer, Schema, ValidationIssue } from "@decs/typeschema";
 import { ServerValidationError } from "./index";
 
-export const isError = (error: any): error is Error => error instanceof Error;
+export const isError = (error: unknown): error is Error => error instanceof Error;
 export const isServerValidationError = <S extends Schema>(error: unknown): error is ServerValidationError<S> => error instanceof ServerValidationError;
 // UTIL TYPES
 
@@ -63,3 +63,7 @@ export const buildValidationErrors = <const S extends Schema>(issues: Validation
 
 	return ve as ValidationErrors<S>;
 };
+
+export const throwServerValidationError = <S extends Schema>(validationErrors: ValidationErrors<S>): never => {
+	throw new ServerValidationError<S>(validationErrors);
+}


### PR DESCRIPTION
I've encountered in almost every project that interacts with an external API a need to return a validation error from the server action. Common example could be when creating a new record that has a unique key (for example email). The server action calls the API and get an error that the email already exists. I usually hacked this and returned a response from server action in similar format to:
```json
{
  "success": false,
  "errors": {
    "email": "Email already exists"
  }
}
```

Then on client side, there's a need for an additional check on the returned data.

This PR aims to add a way for the user to trigger `validationErrors` output from the server action, instead of the described approach above, there's new function passed to the server action, that lets you trigger the `valdiationErrors`.

```ts
const input = z.object({
	email: z.string(),
});

export const registerUser = action(input, async ({ email }, _ctx, serverValidationError) => {
        const emailExists = await db.query.users.findFirst({ where: eq(users.email, email) });       
	if (emailExists) {
		serverValidationError({
			email: ['Email already exists'],
		});
	}
});
```

On the client side, this will return:
```json
{
  "validationErrors": {
    "email": ["Email already exists"]
  }
}
```

Which removes the need to do an additional check on the data, but you can rely on that if `validationErrors` and `serverErrors` are null, your server action succeeded.


Side note: I initially exported the ServerValidationError and wanted the user to throw it manually, but that would require passing `typeof schema` or `schema` to the error, to be able to hint possible validation error keys. The current approach with helper method doesn't require that, but I'm not 100% sold on it....