### PR TITLE
docs(getting-started): add note for Turbopack/Typeschema error

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -53,6 +53,10 @@ export const action = createSafeActionClient();
 
 This is a basic client, without any options. If you want to explore the full set of options, check out the [safe action client](/docs/safe-action-client) section.
 
+:::note
+If you are using the beta Turbopack bundler in Next.js, i.e. `next dev --turbo`, you may encounter `Module not found` errors from **TypeSchema**. If you are also using zod as your validation library, this error can be avoided by instead importing the `createSafeActionClient` from `next-safe-action/zod`.
+:::
+
 ### 2. Define a new action
 
 This is how a safe action is created. Providing a validation input schema to the function, we're sure that data that comes in is type safe and validated.


### PR DESCRIPTION
This pull request adds a note for Turbopack users regarding the "Module not found" error when using the Turbopack bundler in Next.js. The note provides a solution for avoiding the error by importing the `createSafeActionClient` from `next-safe-action/zod` instead of using the default import.

See: https://github.com/TheEdoRan/next-safe-action/issues/49