### PR TITLE
fix(example): return userId from middleware

### DIFF
--- a/packages/example-app/src/lib/safe-action.ts
+++ b/packages/example-app/src/lib/safe-action.ts
@@ -38,6 +38,8 @@ export const authAction = createSafeActionClient({
 			"PARSED INPUT:",
 			parsedInput
 		);
+
+		return userId;
 	},
 	handleReturnedServerError,
 });


### PR DESCRIPTION
The middleware doesn't return userId eventhough it's used in the action