### PR TITLE
refactor: upgrade TypeSchema to v0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -435,80 +435,6 @@
 				"node": ">=v18"
 			}
 		},
-		"node_modules/@decs/typeschema": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@decs/typeschema/-/typeschema-0.12.2.tgz",
-			"integrity": "sha512-PA8uAH/Xfsa5X2UNNSnb5i6vB8qWZywp4+d2U8kNMCO7qwirYRPbFCHwIfWBJyURh4rULn3Ey+VBADLcK2xxaQ==",
-			"deprecated": "TypeSchema has been restructured. Install @typeschema/main or @typeschema/all instead.",
-			"peerDependencies": {
-				"@deepkit/type": "^1.0.1-alpha.113",
-				"@effect/schema": "^0.60.6",
-				"@sinclair/typebox": "^0.32.11",
-				"ajv": "^8.12.0",
-				"arktype": "^1.0.29-alpha",
-				"effect": "^2.1.2",
-				"fp-ts": "^2.16.2",
-				"io-ts": "^2.2.21",
-				"joi": "^17.12.0",
-				"ow": "^0.28.2",
-				"runtypes": "^6.7.0",
-				"superstruct": "^1.0.3",
-				"valibot": "^0.26.0",
-				"vite": "^5.0.12",
-				"yup": "^1.3.3",
-				"zod": "^3.22.4"
-			},
-			"peerDependenciesMeta": {
-				"@deepkit/type": {
-					"optional": true
-				},
-				"@effect/schema": {
-					"optional": true
-				},
-				"@sinclair/typebox": {
-					"optional": true
-				},
-				"ajv": {
-					"optional": true
-				},
-				"arktype": {
-					"optional": true
-				},
-				"effect": {
-					"optional": true
-				},
-				"fp-ts": {
-					"optional": true
-				},
-				"io-ts": {
-					"optional": true
-				},
-				"joi": {
-					"optional": true
-				},
-				"ow": {
-					"optional": true
-				},
-				"runtypes": {
-					"optional": true
-				},
-				"superstruct": {
-					"optional": true
-				},
-				"valibot": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				},
-				"yup": {
-					"optional": true
-				},
-				"zod": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.19.12",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
@@ -2248,6 +2174,139 @@
 			"version": "6.2.7",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.7.tgz",
 			"integrity": "sha512-blctEWbzUFzQx799RZjzzIdBJOXmE37YYEyDtKkx5Dg+V7o/zyyAxLPiI98A2jdTtDgxZleMdfV+7p8WbRJ1OQ=="
+		},
+		"node_modules/@typeschema/core": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@typeschema/core/-/core-0.13.2.tgz",
+			"integrity": "sha512-pAt0MK249/9szYaoPuvzhSfOd3smrLhhwCCpUNB4onX32mRx5F3lzDIveIYGQkLYRq58xOX5sjoW+n72f/MLLw==",
+			"peerDependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"peerDependenciesMeta": {
+				"@types/json-schema": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typeschema/main": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/@typeschema/main/-/main-0.13.7.tgz",
+			"integrity": "sha512-i6ag0uXU21AaReSfXYkTfkqcEMDhbmFUtbgWu6AEcMLcMKpdQ2o3+lXbks9ZkN+93bo5Ie3xr9Ot5K2Md7iyRQ==",
+			"dependencies": {
+				"@typeschema/core": "0.13.2"
+			},
+			"peerDependencies": {
+				"@typeschema/arktype": "0.13.2",
+				"@typeschema/class-validator": "0.1.2",
+				"@typeschema/deepkit": "0.13.4",
+				"@typeschema/effect": "0.13.4",
+				"@typeschema/function": "0.13.2",
+				"@typeschema/io-ts": "0.13.3",
+				"@typeschema/joi": "0.13.3",
+				"@typeschema/json": "0.13.3",
+				"@typeschema/ow": "0.13.3",
+				"@typeschema/runtypes": "0.13.2",
+				"@typeschema/superstruct": "0.13.2",
+				"@typeschema/suretype": "0.1.0",
+				"@typeschema/typebox": "0.13.4",
+				"@typeschema/valibot": "0.13.4",
+				"@typeschema/valita": "0.1.0",
+				"@typeschema/yup": "0.13.3",
+				"@typeschema/zod": "0.13.3"
+			},
+			"peerDependenciesMeta": {
+				"@typeschema/arktype": {
+					"optional": true
+				},
+				"@typeschema/class-validator": {
+					"optional": true
+				},
+				"@typeschema/deepkit": {
+					"optional": true
+				},
+				"@typeschema/effect": {
+					"optional": true
+				},
+				"@typeschema/function": {
+					"optional": true
+				},
+				"@typeschema/io-ts": {
+					"optional": true
+				},
+				"@typeschema/joi": {
+					"optional": true
+				},
+				"@typeschema/json": {
+					"optional": true
+				},
+				"@typeschema/ow": {
+					"optional": true
+				},
+				"@typeschema/runtypes": {
+					"optional": true
+				},
+				"@typeschema/superstruct": {
+					"optional": true
+				},
+				"@typeschema/suretype": {
+					"optional": true
+				},
+				"@typeschema/typebox": {
+					"optional": true
+				},
+				"@typeschema/valibot": {
+					"optional": true
+				},
+				"@typeschema/valita": {
+					"optional": true
+				},
+				"@typeschema/yup": {
+					"optional": true
+				},
+				"@typeschema/zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typeschema/valibot": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/@typeschema/valibot/-/valibot-0.13.4.tgz",
+			"integrity": "sha512-DU095eQ3gy5AS4HGTzWWOmGNMZuAMkV9QQe+TtA6a4rdGzBS7c2KPG4IKcs14yIJ/PsSHHrEdODpRms6qF1vJQ==",
+			"dependencies": {
+				"@typeschema/core": "0.13.2"
+			},
+			"peerDependencies": {
+				"@gcornut/valibot-json-schema": "^0.0.25",
+				"valibot": "^0.29.0"
+			},
+			"peerDependenciesMeta": {
+				"@gcornut/valibot-json-schema": {
+					"optional": true
+				},
+				"valibot": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typeschema/zod": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/@typeschema/zod/-/zod-0.13.3.tgz",
+			"integrity": "sha512-p5Hs22WIKkM/vZTAvw5QOLSA0EJ6QBUsQMGUrXlYnTAE2LSR/F5MLsDUb18O6S5VxGjrzU7x3VIznD5qOafJRw==",
+			"dependencies": {
+				"@typeschema/core": "0.13.2"
+			},
+			"peerDependencies": {
+				"zod": "^3.22.4",
+				"zod-to-json-schema": "^3.22.4"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				},
+				"zod-to-json-schema": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "7.1.1",
@@ -13049,6 +13108,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@hookform/resolvers": "^3.3.4",
+				"@typeschema/valibot": "^0.13.4",
+				"@typeschema/zod": "^0.13.3",
 				"lucide-react": "^0.354.0",
 				"next": "14.1.3",
 				"next-safe-action": "file:../next-safe-action",
@@ -13075,11 +13136,12 @@
 			"version": "0.0.0-development",
 			"license": "MIT",
 			"dependencies": {
-				"@decs/typeschema": "^0.12.2"
+				"@typeschema/main": "^0.13.7"
 			},
 			"devDependencies": {
 				"@types/node": "^20.11.25",
 				"@types/react": "^18.2.64",
+				"@typeschema/zod": "^0.13.3",
 				"@typescript-eslint/eslint-plugin": "^7.1.1",
 				"@typescript-eslint/parser": "^7.1.1",
 				"eslint": "^8.57.0",

--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -11,14 +11,16 @@
 	"license": "MIT",
 	"author": "Edoardo Ranghieri",
 	"dependencies": {
-		"lucide-react": "^0.354.0",
 		"@hookform/resolvers": "^3.3.4",
+		"@typeschema/valibot": "^0.13.4",
+		"@typeschema/zod": "^0.13.3",
+		"lucide-react": "^0.354.0",
 		"next": "14.1.3",
 		"next-safe-action": "file:../next-safe-action",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
-		"valibot": "^0.30.0",
 		"react-hook-form": "^7.51.0",
+		"valibot": "^0.30.0",
 		"zod": "^3.22.4",
 		"zod-form-data": "^2.0.2"
 	},

--- a/packages/next-safe-action/package.json
+++ b/packages/next-safe-action/package.json
@@ -53,6 +53,7 @@
 	"devDependencies": {
 		"@types/node": "^20.11.25",
 		"@types/react": "^18.2.64",
+		"@typeschema/zod": "^0.13.3",
 		"@typescript-eslint/eslint-plugin": "^7.1.1",
 		"@typescript-eslint/parser": "^7.1.1",
 		"eslint": "^8.57.0",
@@ -73,6 +74,6 @@
 		"url": "https://github.com/TheEdoRan/next-safe-action.git"
 	},
 	"dependencies": {
-		"@decs/typeschema": "^0.12.2"
+		"@typeschema/main": "^0.13.7"
 	}
 }

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { InferIn, Schema } from "@decs/typeschema";
+import type { InferIn, Schema } from "@typeschema/main";
 import { isNotFoundError } from "next/dist/client/components/not-found.js";
 import { isRedirectError } from "next/dist/client/components/redirect.js";
 import * as React from "react";

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -1,5 +1,5 @@
-import type { Infer, InferIn, Schema } from "@decs/typeschema";
-import { wrap } from "@decs/typeschema";
+import type { Infer, InferIn, Schema } from "@typeschema/main";
+import { validate } from "@typeschema/main";
 import { isNotFoundError } from "next/dist/client/components/not-found.js";
 import { isRedirectError } from "next/dist/client/components/redirect.js";
 import type { ErrorList, Extend, MaybePromise, SchemaErrors } from "./utils";
@@ -84,10 +84,10 @@ export const createSafeActionClient = <Context, MiddlewareData>(
 		// all the invalid fields provided.
 		return async (clientInput) => {
 			try {
-				const parsedInput = await wrap(schema).validate(clientInput);
+				const parsedInput = await validate(schema, clientInput);
 
 				// If schema validation fails.
-				if ("issues" in parsedInput) {
+				if (!parsedInput.success) {
 					return {
 						validationErrors: buildValidationErrors<S>(parsedInput.issues),
 					};

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,4 +1,5 @@
-import type { Schema, ValidationIssue } from "@decs/typeschema";
+import type { ValidationIssue } from "@typeschema/core";
+import type { Schema } from "@typeschema/main";
 import type { ValidationErrors } from ".";
 
 export const isError = (error: unknown): error is Error => error instanceof Error;

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -10,36 +10,26 @@ This is the documentation for the current version of the library (7.x.x).
 :::
 
 :::info Requirements
-- v4: Next.js >= 13.4.2, v5: Next.js >= 14.0.0
+- Next.js >= 14.0.0
 - TypeScript >= 5.0.0
-- pre-v6: Zod >= 3.0.0, from v6: a validation library supported by [TypeSchema](https://typeschema.com/#coverage)
+- a validation library supported by [TypeSchema](https://typeschema.com/#coverage)
 :::
 
 **next-safe-action** provides a typesafe Server Actions implementation for Next.js App Router.
 
 ## Validation libraries support
 
-We will use Zod as our validation library in this documentation, but since version 6 of next-safe-action, you can use your validation library of choice, or even multiple and custom ones at the same time, thanks to the **TypeSchema** library. You can find supported libraries [here](https://typeschema.com/#coverage).
+We will use Zod as our validation library in this documentation, but since version 6 of next-safe-action, you can use your validation library of choice, or even multiple and custom ones at the same time, thanks to the **TypeSchema** library. Note that we also need to install the related TypeSchema adapter for our validation library of choice. You can find supported libraries and related adapters [here](https://typeschema.com/#coverage).
 
 ## Installation
 
-For Next.js >= 14, use the following command:
+For Next.js >= 14, assuming you want to use Zod as your validation library, use the following command:
 
 ```bash npm2yarn
-npm i next-safe-action
-```
-
-For Next.js 13, use the following command:
-
-```bash npm2yarn
-npm i next-safe-action@v4 zod
+npm i next-safe-action zod @typeschema/zod
 ```
 
 ## Usage
-
-:::note
-If you're still using Next.js 13 with next-safe-action v4, you need to enable `serverActions` flag under the `experimental` object in next.config.js file. Find out more [here](/docs/migrations/v4-to-v5).
-:::
 
 ### 1. Instantiate a new client
 


### PR DESCRIPTION
This PR upgrades TypeSchema from v0.12 to v0.13. v0.13 is a major refactor of the library, which switched to a modular design. From now on, next-safe-action will use @typeschema/main to just include the common adapter logic without actually bundling adapters. This keeps the bundle size small, while allowing users to choose the specific validation libraries (and adapters) they want to use.