### PR TITLE
feat: add ability to wrap execution of server actions

### DIFF
--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -79,7 +79,7 @@ export const createSafeActionClient = <Context, MiddlewareData>(
 		schema: S,
 		serverCode: ServerCodeFn<S, Data, Context>,
 		utils?: {
-			actionName: string;
+			actionName?: string;
 			middlewareData?: MiddlewareData;
 		}
 	): SafeAction<S, Data> => {


### PR DESCRIPTION
Adds the ability to wrap the execution of server actions by passing in a "wrapExecution" function when creating the safe action client where you can inject things like logging, tracing or performance monitoring. To do these things you also want the name of the action, which I've passed in via the utils object in this PR. This is backwards compatible without breaking changes.

Optimally I think this kind of functionality would best be implemented by changing the current middleware approach to one more similar to what playwright does with their [fixtures](https://playwright.dev/docs/test-fixtures) but that would be a breaking change.

Written blind to get feedback before committing too much time, this has not yet been tested.

Example usage:
```ts
const performanceAction = createSafeActionClient({
  async wrapExecution(serverCode, parsedInput, ctx, actionName) {
    const t1 = performance.now();
    const res = await serverCode(parsedInput, ctx);
    const t2 = performance.now();
    
    // Prints 'Action "someAction" took 1000 milliseconds.'
    console.log(`Action "${actionName}" took ${t2 - t1} milliseconds.`);
    
    return res;
  },
});

const someAction = performanceAction(
  {
    name: z.string(),
  },
  async (input, ctx) => {
    await new Promise((resolve) => setTimeout(resolve, 1000));
  },
  {
    actionName: "someAction",
  }
);

```