### PR TITLE
feat(validation-errors): support flattening via `flattenValidationErrors` function

### DIFF
--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -16,6 +16,7 @@ import { DEFAULT_SERVER_ERROR_MESSAGE, isError } from "./utils";
 import {
 	ServerValidationError,
 	buildValidationErrors,
+	flattenValidationErrors,
 	returnValidationErrors,
 } from "./validation-errors";
 import type { BindArgsValidationErrors, ValidationErrors } from "./validation-errors.types";
@@ -291,19 +292,16 @@ export const createSafeActionClient = <const ServerError = string>(
 	});
 };
 
-export {
-	DEFAULT_SERVER_ERROR_MESSAGE,
-	returnValidationErrors,
-	type BindArgsValidationErrors,
-	type ValidationErrors,
-};
+export { DEFAULT_SERVER_ERROR_MESSAGE, flattenValidationErrors, returnValidationErrors };
 
 export type {
 	ActionMetadata,
+	BindArgsValidationErrors,
 	MiddlewareFn,
 	MiddlewareResult,
 	SafeActionClientOpts,
 	SafeActionFn,
 	SafeActionResult,
 	ServerCodeFn,
+	ValidationErrors,
 };

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -24,3 +24,14 @@ export type ValidationErrors<S extends Schema> = Extend<ErrorList & SchemaErrors
 export type BindArgsValidationErrors<BAS extends Schema[]> = (ValidationErrors<
 	BAS[number]
 > | null)[];
+
+/**
+ * Type of flattened validation errors. `rootErrors` contains global errors, and `fieldErrors`
+ * contains errors for each field, one level deep.
+ */
+export type FlattenedValidationErrors<S extends Schema, VE extends ValidationErrors<S>> = {
+	rootErrors: string[];
+	fieldErrors: {
+		[K in keyof Omit<VE, "_errors">]?: string[];
+	};
+};


### PR DESCRIPTION
Sometimes it's better to deal with a flattened error object instead of a formatted one, for instance when you don't need to use nested objects in validation schemas.

This PR exports a function called `flattenValidationErrors` that does what it says. Be aware that it works just one level deep, as it discards nested schema errors. This is a known limitation of this approach, since it can't prevent key conflicts.

Suppose this is a returned formatted `validationErrors` object: 

```typescript
validationErrors = {
  _errors: ["Global error"],
  username: {
    _errors: ["Too short", "Username is invalid"],
  },
  email: {
    _errors: ["Email is invalid"],
  }
}
```

After passing it to `flattenValidationErrors`:

```typescript
import { flattenValidationErrors } from "next-safe-action";

const flattenedErrors = flattenValidationErrors(validationErrors);
```

It becomes this:

```typescript
flattenedErrors = {
  rootErrors: ["Global error"],
  fieldErrors: {
    username: ["Too short", "Username is invalid"],
    email: ["Email is invalid"],
  }
}
```