### PR TITLE
feat: allow omitting schema argument in `schema` method

### DIFF
--- a/packages/example-app/src/app/(examples)/empty-schema/empty-action.ts
+++ b/packages/example-app/src/app/(examples)/empty-schema/empty-action.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { action } from "@/lib/safe-action";
+
+export const emptyAction = action
+	.metadata({ actionName: "onboardUser" })
+	.schema()
+	.action(async () => {
+		await new Promise((res) => setTimeout(res, 500));
+
+		return {
+			message: "Well done!",
+		};
+	});

--- a/packages/example-app/src/app/(examples)/empty-schema/page.tsx
+++ b/packages/example-app/src/app/(examples)/empty-schema/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { StyledButton } from "@/app/_components/styled-button";
+import { StyledHeading } from "@/app/_components/styled-heading";
+import { useAction } from "next-safe-action/hooks";
+import { ResultBox } from "../../_components/result-box";
+import { emptyAction } from "./empty-action";
+
+export default function EmptySchema() {
+	const { execute, result, status, reset } = useAction(emptyAction, {
+		onSuccess({ data, input, reset }) {
+			console.log("HELLO FROM ONSUCCESS", data, input);
+
+			// You can reset result object by calling `reset`.
+			// reset();
+		},
+		onError({ error, input, reset }) {
+			console.log("OH NO FROM ONERROR", error, input);
+
+			// You can reset result object by calling `reset`.
+			// reset();
+		},
+		onSettled({ result, input, reset }) {
+			console.log("HELLO FROM ONSETTLED", result, input);
+
+			// You can reset result object by calling `reset`.
+			// reset();
+		},
+		onExecute({ input }) {
+			console.log("HELLO FROM ONEXECUTE", input);
+		},
+	});
+
+	console.log("status:", status);
+
+	return (
+		<main className="w-96 max-w-full px-4">
+			<StyledHeading>Action without schema</StyledHeading>
+			<form
+				className="flex flex-col mt-8 space-y-4"
+				onSubmit={(e) => {
+					e.preventDefault();
+					const formData = new FormData(e.currentTarget);
+
+					// Action call.
+					execute();
+				}}>
+				<StyledButton type="submit">Execute action</StyledButton>
+				<StyledButton type="button" onClick={reset}>
+					Reset
+				</StyledButton>
+			</form>
+			<ResultBox result={result} status={status} />
+		</main>
+	);
+}

--- a/packages/example-app/src/app/page.tsx
+++ b/packages/example-app/src/app/page.tsx
@@ -15,6 +15,7 @@ export default function Home() {
 					<span className="font-mono">useOptimisticAction</span> hook
 				</ExampleLink>
 				<ExampleLink href="/bind-arguments">Bind arguments</ExampleLink>
+				<ExampleLink href="/empty-schema">Empty schema</ExampleLink>
 				<ExampleLink href="/server-form">Server Form</ExampleLink>
 				<ExampleLink href="/client-form">Client Form</ExampleLink>
 				<ExampleLink href="/react-hook-form">React Hook Form</ExampleLink>

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -19,7 +19,7 @@ const DEFAULT_RESULT = {
 
 const getActionStatus = <
 	const ServerError,
-	const S extends Schema,
+	const S extends Schema | undefined,
 	const BAS extends readonly Schema[],
 	const FVE,
 	const FBAVE,
@@ -49,7 +49,7 @@ const getActionStatus = <
 
 const useActionCallbacks = <
 	const ServerError,
-	const S extends Schema,
+	const S extends Schema | undefined,
 	const BAS extends readonly Schema[],
 	const FVE,
 	const FBAVE,
@@ -62,7 +62,7 @@ const useActionCallbacks = <
 	cb,
 }: {
 	result: HookResult<ServerError, S, BAS, FVE, FBAVE, Data>;
-	input: InferIn<S>;
+	input: S extends Schema ? InferIn<S> : undefined;
 	status: HookActionStatus;
 	reset: () => void;
 	cb?: HookCallbacks<ServerError, S, BAS, FVE, FBAVE, Data>;
@@ -110,7 +110,7 @@ const useActionCallbacks = <
  */
 export const useAction = <
 	const ServerError,
-	const S extends Schema,
+	const S extends Schema | undefined,
 	const BAS extends readonly Schema[],
 	const FVE,
 	const FBAVE,
@@ -122,13 +122,13 @@ export const useAction = <
 	const [, startTransition] = React.useTransition();
 	const [result, setResult] =
 		React.useState<HookResult<ServerError, S, BAS, FVE, FBAVE, Data>>(DEFAULT_RESULT);
-	const [input, setInput] = React.useState<InferIn<S>>();
+	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : undefined>();
 	const [isExecuting, setIsExecuting] = React.useState(false);
 
 	const status = getActionStatus<ServerError, S, BAS, FVE, FBAVE, Data>({ isExecuting, result });
 
 	const execute = React.useCallback(
-		(input: InferIn<S>) => {
+		(input: S extends Schema ? InferIn<S> : undefined) => {
 			setInput(input);
 			setIsExecuting(true);
 
@@ -154,7 +154,13 @@ export const useAction = <
 		setResult(DEFAULT_RESULT);
 	}, []);
 
-	useActionCallbacks({ result, input, status, reset, cb: callbacks });
+	useActionCallbacks({
+		result,
+		input: input as S extends Schema ? InferIn<S> : undefined,
+		status,
+		reset,
+		cb: callbacks,
+	});
 
 	return {
 		execute,
@@ -177,7 +183,7 @@ export const useAction = <
  */
 export const useOptimisticAction = <
 	const ServerError,
-	const S extends Schema,
+	const S extends Schema | undefined,
 	const BAS extends readonly Schema[],
 	const FVE,
 	const FBAVE,
@@ -185,24 +191,24 @@ export const useOptimisticAction = <
 >(
 	safeActionFn: HookSafeActionFn<ServerError, S, BAS, FVE, FBAVE, Data>,
 	initialOptimisticData: Data,
-	reducer: (state: Data, input: InferIn<S>) => Data,
+	reducer: (state: Data, input: S extends Schema ? InferIn<S> : undefined) => Data,
 	callbacks?: HookCallbacks<ServerError, S, BAS, FVE, FBAVE, Data>
 ) => {
 	const [, startTransition] = React.useTransition();
 	const [result, setResult] =
 		React.useState<HookResult<ServerError, S, BAS, FVE, FBAVE, Data>>(DEFAULT_RESULT);
-	const [input, setInput] = React.useState<InferIn<S>>();
+	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : undefined>();
 	const [isExecuting, setIsExecuting] = React.useState(false);
 
-	const [optimisticData, setOptimisticState] = React.useOptimistic<Data, InferIn<S>>(
-		initialOptimisticData,
-		reducer
-	);
+	const [optimisticData, setOptimisticState] = React.useOptimistic<
+		Data,
+		S extends Schema ? InferIn<S> : undefined
+	>(initialOptimisticData, reducer);
 
 	const status = getActionStatus<ServerError, S, BAS, FVE, FBAVE, Data>({ isExecuting, result });
 
 	const execute = React.useCallback(
-		(input: InferIn<S>) => {
+		(input: S extends Schema ? InferIn<S> : undefined) => {
 			setInput(input);
 			setIsExecuting(true);
 
@@ -229,7 +235,13 @@ export const useOptimisticAction = <
 		setResult(DEFAULT_RESULT);
 	}, []);
 
-	useActionCallbacks({ result, input, status, reset, cb: callbacks });
+	useActionCallbacks({
+		result,
+		input: input as S extends Schema ? InferIn<S> : undefined,
+		status,
+		reset,
+		cb: callbacks,
+	});
 
 	return {
 		execute,

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -122,18 +122,18 @@ export const useAction = <
 	const [, startTransition] = React.useTransition();
 	const [result, setResult] =
 		React.useState<HookResult<ServerError, S, BAS, FVE, FBAVE, Data>>(DEFAULT_RESULT);
-	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : undefined>();
+	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : void>();
 	const [isExecuting, setIsExecuting] = React.useState(false);
 
 	const status = getActionStatus<ServerError, S, BAS, FVE, FBAVE, Data>({ isExecuting, result });
 
 	const execute = React.useCallback(
-		(input: S extends Schema ? InferIn<S> : undefined) => {
+		(input: S extends Schema ? InferIn<S> : void) => {
 			setInput(input);
 			setIsExecuting(true);
 
 			return startTransition(() => {
-				return safeActionFn(input)
+				return safeActionFn(input as S extends Schema ? InferIn<S> : undefined)
 					.then((res) => setResult(res ?? DEFAULT_RESULT))
 					.catch((e) => {
 						if (isRedirectError(e) || isNotFoundError(e)) {
@@ -197,7 +197,7 @@ export const useOptimisticAction = <
 	const [, startTransition] = React.useTransition();
 	const [result, setResult] =
 		React.useState<HookResult<ServerError, S, BAS, FVE, FBAVE, Data>>(DEFAULT_RESULT);
-	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : undefined>();
+	const [input, setInput] = React.useState<S extends Schema ? InferIn<S> : void>();
 	const [isExecuting, setIsExecuting] = React.useState(false);
 
 	const [optimisticData, setOptimisticState] = React.useOptimistic<
@@ -208,13 +208,13 @@ export const useOptimisticAction = <
 	const status = getActionStatus<ServerError, S, BAS, FVE, FBAVE, Data>({ isExecuting, result });
 
 	const execute = React.useCallback(
-		(input: S extends Schema ? InferIn<S> : undefined) => {
+		(input: S extends Schema ? InferIn<S> : void) => {
 			setInput(input);
 			setIsExecuting(true);
 
 			return startTransition(() => {
-				setOptimisticState(input);
-				return safeActionFn(input)
+				setOptimisticState(input as S extends Schema ? InferIn<S> : undefined);
+				return safeActionFn(input as S extends Schema ? InferIn<S> : undefined)
 					.then((res) => setResult(res ?? DEFAULT_RESULT))
 					.catch((e) => {
 						if (isRedirectError(e) || isNotFoundError(e)) {

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -8,7 +8,7 @@ import type { MaybePromise } from "./utils";
  */
 export type HookResult<
 	ServerError,
-	S extends Schema,
+	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	FVE,
 	FBAVE,
@@ -22,22 +22,26 @@ export type HookResult<
  */
 export type HookCallbacks<
 	ServerError,
-	S extends Schema,
+	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	FVE,
 	FBAVE,
 	Data,
 > = {
-	onExecute?: (args: { input: InferIn<S> }) => MaybePromise<void>;
-	onSuccess?: (args: { data: Data; input: InferIn<S>; reset: () => void }) => MaybePromise<void>;
+	onExecute?: (args: { input: S extends Schema ? InferIn<S> : undefined }) => MaybePromise<void>;
+	onSuccess?: (args: {
+		data: Data;
+		input: S extends Schema ? InferIn<S> : undefined;
+		reset: () => void;
+	}) => MaybePromise<void>;
 	onError?: (args: {
 		error: Omit<HookResult<ServerError, S, BAS, FVE, FBAVE, Data>, "data">;
-		input: InferIn<S>;
+		input: S extends Schema ? InferIn<S> : undefined;
 		reset: () => void;
 	}) => MaybePromise<void>;
 	onSettled?: (args: {
 		result: HookResult<ServerError, S, BAS, FVE, FBAVE, Data>;
-		input: InferIn<S>;
+		input: S extends Schema ? InferIn<S> : undefined;
 		reset: () => void;
 	}) => MaybePromise<void>;
 };
@@ -48,12 +52,14 @@ export type HookCallbacks<
  */
 export type HookSafeActionFn<
 	ServerError,
-	S extends Schema,
+	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	FVE,
 	FBAVE,
 	Data,
-> = (clientInput: InferIn<S>) => Promise<SafeActionResult<ServerError, S, BAS, FVE, FBAVE, Data>>;
+> = (
+	clientInput: S extends Schema ? InferIn<S> : undefined
+) => Promise<SafeActionResult<ServerError, S, BAS, FVE, FBAVE, Data>>;
 
 /**
  * Type of the action status returned by `useAction` and `useOptimisticAction` hooks.

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -16,7 +16,7 @@ export type SafeActionClientOpts<ServerError, MetadataSchema extends Schema | un
  */
 export type SafeActionResult<
 	ServerError,
-	S extends Schema,
+	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	FVE = ValidationErrors<S>,
 	FBAVE = BindArgsValidationErrors<BAS>,
@@ -35,13 +35,13 @@ export type SafeActionResult<
  */
 export type SafeActionFn<
 	ServerError,
-	S extends Schema,
+	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	FVE,
 	FBAVE,
 	Data,
 > = (
-	...clientInputs: [...InferInArray<BAS>, InferIn<S>]
+	...clientInputs: [...InferInArray<BAS>, S extends Schema ? InferIn<S> : void]
 ) => Promise<SafeActionResult<ServerError, S, BAS, FVE, FBAVE, Data>>;
 
 /**
@@ -81,8 +81,14 @@ export type MiddlewareFn<ServerError, Ctx, NextCtx, MD> = {
 /**
  * Type of the function that executes server code when defining a new safe action.
  */
-export type ServerCodeFn<S extends Schema, BAS extends readonly Schema[], Data, Ctx, MD> = (args: {
-	parsedInput: Infer<S>;
+export type ServerCodeFn<
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	Data,
+	Ctx,
+	MD,
+> = (args: {
+	parsedInput: S extends Schema ? Infer<S> : undefined;
 	bindArgsParsedInputs: InferArray<BAS>;
 	ctx: Ctx;
 	metadata: MD;

--- a/packages/next-safe-action/src/validation-errors.ts
+++ b/packages/next-safe-action/src/validation-errors.ts
@@ -8,7 +8,9 @@ import type {
 } from "./validation-errors.types";
 
 // This function is used internally to build the validation errors object from a list of validation issues.
-export const buildValidationErrors = <const S extends Schema>(issues: ValidationIssue[]) => {
+export const buildValidationErrors = <const S extends Schema | undefined>(
+	issues: ValidationIssue[]
+) => {
 	const ve: any = {};
 
 	for (const issue of issues) {
@@ -91,7 +93,9 @@ export function flattenValidationErrors<const VE extends ValidationErrors<any>>(
 		fieldErrors: {},
 	};
 
-	for (const [key, value] of Object.entries<string[] | { _errors: string[] }>(validationErrors)) {
+	for (const [key, value] of Object.entries<string[] | { _errors: string[] }>(
+		validationErrors ?? {}
+	)) {
 		if (key === "_errors" && Array.isArray(value)) {
 			flattened.formErrors = [...value];
 		} else {

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -34,14 +34,12 @@ export type BindArgsValidationErrors<BAS extends readonly Schema[]> = {
  * Type of flattened validation errors. `formErrors` contains global errors, and `fieldErrors`
  * contains errors for each field, one level deep.
  */
-export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = VE extends undefined
-	? undefined
-	: Prettify<{
-			formErrors: string[];
-			fieldErrors: {
-				[K in keyof Omit<VE, "_errors">]?: string[];
-			};
-		}>;
+export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = Prettify<{
+	formErrors: string[];
+	fieldErrors: {
+		[K in keyof Omit<VE, "_errors">]?: string[];
+	};
+}>;
 
 /**
  * Type of flattened bind arguments validation errors.

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -17,8 +17,11 @@ type SchemaErrors<S> = {
 /**
  * Type of the returned object when input validation fails.
  */
-export type ValidationErrors<S extends Schema> =
-	Infer<S> extends object ? PrettyMerge<ErrorList & SchemaErrors<Infer<S>>> : ErrorList;
+export type ValidationErrors<S extends Schema | undefined> = S extends Schema
+	? Infer<S> extends object
+		? PrettyMerge<ErrorList & SchemaErrors<Infer<S>>>
+		: ErrorList
+	: undefined;
 
 /**
  * Type of the array of validation errors of bind arguments.
@@ -31,12 +34,14 @@ export type BindArgsValidationErrors<BAS extends readonly Schema[]> = {
  * Type of flattened validation errors. `formErrors` contains global errors, and `fieldErrors`
  * contains errors for each field, one level deep.
  */
-export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = Prettify<{
-	formErrors: string[];
-	fieldErrors: {
-		[K in keyof Omit<VE, "_errors">]?: string[];
-	};
-}>;
+export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = VE extends undefined
+	? undefined
+	: Prettify<{
+			formErrors: string[];
+			fieldErrors: {
+				[K in keyof Omit<VE, "_errors">]?: string[];
+			};
+		}>;
 
 /**
  * Type of flattened bind arguments validation errors.
@@ -48,7 +53,7 @@ export type FlattenedBindArgsValidationErrors<BAVE extends readonly ValidationEr
 /**
  * Type of the function used to format validation errors.
  */
-export type FormatValidationErrorsFn<S extends Schema, FVE> = (
+export type FormatValidationErrorsFn<S extends Schema | undefined, FVE> = (
 	validationErrors: ValidationErrors<S>
 ) => FVE;
 

--- a/website/docs/safe-action-client/instance-methods.md
+++ b/website/docs/safe-action-client/instance-methods.md
@@ -36,10 +36,10 @@ metadata(data: Metadata) => { schema() }
 ## `schema`
 
 ```typescript
-schema<const S extends Schema, const FVE = ValidationErrors<S>, const MD = null>(schema: S, { utils?: { formatValidationErrors?: FormatValidationErrorsFn<S, FVE> } }) => { action(), bindArgsSchemas() }
+schema<const S extends Schema | undefined = undefined, const FVE = ValidationErrors<S>, const MD = null>(schema: S, { utils?: { formatValidationErrors?: FormatValidationErrorsFn<S, FVE> } }) => { action(), bindArgsSchemas() }
 ```
 
-`schema` accepts an input schema of type `Schema` (from TypeSchema) and an optional `utils` object that accepts a `formatValidationErrors` function. The schema is used to define the arguments that the safe action will receive, the optional `formatValidationErrors` function is used to [return a custom format for validation errors](/docs/recipes/customize-validation-errors-format). It returns the [`action`](#action) and [`bindArgsSchemas`](#bindargsschemas) methods, which allows you, respectively, to define a new action using that input schema or extend the arguments with additional bound ones.
+`schema` accepts an **optional** input schema of type `Schema` (from TypeSchema) and an optional `utils` object that accepts a [`formatValidationErrors`](/docs/recipes/customize-validation-errors-format) function. The schema is used to define the arguments that the safe action will receive, the optional [`formatValidationErrors`](/docs/recipes/customize-validation-errors-format) function is used to return a custom format for validation errors. If you don't pass an input schema, `parsedInput` and validation errors will be typed `undefined`, and `clientInput` will be typed `void`. It returns the [`action`](#action) and [`bindArgsSchemas`](#bindargsschemas) methods, which allows you, respectively, to define a new action using that input schema or extend the arguments with additional bound ones.
 
 ## `bindArgsSchemas`
 

--- a/website/docs/types.md
+++ b/website/docs/types.md
@@ -135,14 +135,12 @@ export type BindArgsValidationErrors<BAS extends readonly Schema[]> = {
 Type of flattened validation errors. `formErrors` contains global errors, and `fieldErrors` contains errors for each field, one level deep.
 
 ```typescript
-export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = VE extends undefined
-  ? undefined
-  : Prettify<{
-      formErrors: string[];
-      fieldErrors: {
-        [K in keyof Omit<VE, "_errors">]?: string[];
-      };
-    }>;
+export type FlattenedValidationErrors<VE extends ValidationErrors<any>> = Prettify<{
+  formErrors: string[];
+  fieldErrors: {
+    [K in keyof Omit<VE, "_errors">]?: string[];
+  };
+}>;
 ```
 
 ### `FlattenedBindArgsValidationErrors`


### PR DESCRIPTION
This PR adds the ability to omit passing a validation schema to the `schema` method.