### PR TITLE
refactor(hooks): use separate type for server state in `useOptimisticAction`

### DIFF
--- a/apps/playground/src/app/(examples)/optimistic-hook/addtodo-action.ts
+++ b/apps/playground/src/app/(examples)/optimistic-hook/addtodo-action.ts
@@ -4,38 +4,36 @@ import { ActionError, action } from "@/lib/safe-action";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
-let likes = 42;
-
-export const getLikes = async () => likes;
-
-const incrementLikes = (by: number) => {
-	likes += by;
-	return likes;
-};
-
 const schema = z.object({
-	incrementBy: z.number(),
+	id: z.string().uuid(),
+	body: z.string().min(1),
+	completed: z.boolean(),
 });
 
-export const addLikes = action
-	.metadata({ actionName: "addLikes" })
+export type Todo = z.infer<typeof schema>;
+
+let todos: Todo[] = [];
+export const getTodos = async () => todos;
+
+export const addTodo = action
+	.metadata({ actionName: "" })
 	.schema(schema)
-	.action(async ({ parsedInput: { incrementBy } }) => {
+	.action(async ({ parsedInput }) => {
 		await new Promise((res) => setTimeout(res, 500));
 
 		if (Math.random() > 0.5) {
 			throw new ActionError(
-				"Could not update likes right now, please try again later."
+				"Could not add todo right now, please try again later."
 			);
 		}
 
-		const likesCount = incrementLikes(incrementBy);
+		todos.push(parsedInput);
 
 		// This Next.js function revalidates the provided path.
 		// More info here: https://nextjs.org/docs/app/api-reference/functions/revalidatePath
 		revalidatePath("/optimistic-hook");
 
 		return {
-			likesCount,
+			newTodo: parsedInput,
 		};
 	});

--- a/apps/playground/src/app/(examples)/optimistic-hook/addtodo-form.tsx
+++ b/apps/playground/src/app/(examples)/optimistic-hook/addtodo-form.tsx
@@ -4,19 +4,19 @@ import { StyledButton } from "@/app/_components/styled-button";
 import { StyledInput } from "@/app/_components/styled-input";
 import { useOptimisticAction } from "next-safe-action/hooks";
 import { ResultBox } from "../../_components/result-box";
-import { addLikes } from "./addlikes-action";
+import { Todo, addTodo } from "./addtodo-action";
 
 type Props = {
-	likesCount: number;
+	todos: Todo[];
 };
 
-const AddLikesForm = ({ likesCount }: Props) => {
-	// Here we pass safe action (`addLikes`) and current server data to `useOptimisticAction` hook.
-	const { execute, result, status, reset, optimisticData } =
-		useOptimisticAction(addLikes, {
-			currentData: { likesCount },
-			updateFn: (prevData, { incrementBy }) => ({
-				likesCount: prevData.likesCount + incrementBy,
+const AddTodoForm = ({ todos }: Props) => {
+	// Here we pass safe action (`addTodo`) and current server data to `useOptimisticAction` hook.
+	const { execute, result, status, reset, optimisticState } =
+		useOptimisticAction(addTodo, {
+			currentState: { todos },
+			updateFn: (prevState, newTodo) => ({
+				todos: [...prevState.todos, newTodo],
 			}),
 			onSuccess({ data, input }) {
 				console.log("HELLO FROM ONSUCCESS", data, input);
@@ -41,35 +41,25 @@ const AddLikesForm = ({ likesCount }: Props) => {
 				onSubmit={(e) => {
 					e.preventDefault();
 					const formData = new FormData(e.currentTarget);
-					const input = Object.fromEntries(formData) as {
-						incrementBy: string;
-					};
-
-					const intIncrementBy = parseInt(input.incrementBy);
+					const body = formData.get("body") as string;
 
 					// Action call. Here we pass action input and expected (optimistic)
 					// data.
-					execute({ incrementBy: intIncrementBy });
+					execute({ id: crypto.randomUUID(), body, completed: false });
 				}}>
-				<StyledInput
-					type="text"
-					name="incrementBy"
-					id="incrementBy"
-					placeholder="Increment by"
-				/>
-				<StyledButton type="submit">Add likes</StyledButton>
+				<StyledInput type="text" name="body" placeholder="Todo body" />
+				<StyledButton type="submit">Add todo</StyledButton>
 				<StyledButton type="button" onClick={reset}>
 					Reset
 				</StyledButton>
 			</form>
 			<ResultBox
-				result={optimisticData}
+				result={optimisticState}
 				status={status}
 				customTitle="Optimistic data:"
 			/>
-			<ResultBox result={result} customTitle="Actual result:" />
 		</>
 	);
 };
 
-export default AddLikesForm;
+export default AddTodoForm;

--- a/apps/playground/src/app/(examples)/optimistic-hook/page.tsx
+++ b/apps/playground/src/app/(examples)/optimistic-hook/page.tsx
@@ -1,18 +1,15 @@
 import { StyledHeading } from "@/app/_components/styled-heading";
-import { getLikes } from "./addlikes-action";
-import AddLikeForm from "./addlikes-form";
+import { getTodos } from "./addtodo-action";
+import AddTodoForm from "./addtodo-form";
 
 export default async function OptimisticHookPage() {
-	const likesCount = await getLikes();
+	const todos = await getTodos();
 
 	return (
 		<main className="w-96 max-w-full px-4">
 			<StyledHeading>Action using optimistic hook</StyledHeading>
-			<pre className="mt-4 text-center">
-				Server data: {JSON.stringify(likesCount)}
-			</pre>
 			{/* Pass the server state to Client Component */}
-			<AddLikeForm likesCount={likesCount} />
+			<AddTodoForm todos={todos} />
 		</main>
 	);
 }

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -205,11 +205,12 @@ export const useOptimisticAction = <
 	FVE,
 	FBAVE,
 	Data,
+	State,
 >(
 	safeActionFn: HookSafeActionFn<ServerError, S, BAS, FVE, FBAVE, Data>,
 	utils: {
-		currentData: Data;
-		updateFn: (prevData: Data, input: S extends Schema ? InferIn<S> : undefined) => Data;
+		currentState: State;
+		updateFn: (prevState: State, input: S extends Schema ? InferIn<S> : undefined) => State;
 	} & HookCallbacks<ServerError, S, BAS, FVE, FBAVE, Data>
 ) => {
 	const [, startTransition] = React.useTransition();
@@ -217,8 +218,8 @@ export const useOptimisticAction = <
 	const [clientInput, setClientInput] = React.useState<S extends Schema ? InferIn<S> : void>();
 	const [isExecuting, setIsExecuting] = React.useState(false);
 	const [isIdle, setIsIdle] = React.useState(true);
-	const [optimisticData, setOptimisticData] = React.useOptimistic<Data, S extends Schema ? InferIn<S> : undefined>(
-		utils.currentData,
+	const [optimisticState, setOptimisticState] = React.useOptimistic<State, S extends Schema ? InferIn<S> : undefined>(
+		utils.currentState,
 		utils.updateFn
 	);
 
@@ -231,7 +232,7 @@ export const useOptimisticAction = <
 			setIsExecuting(true);
 
 			return startTransition(() => {
-				setOptimisticData(input as S extends Schema ? InferIn<S> : undefined);
+				setOptimisticState(input as S extends Schema ? InferIn<S> : undefined);
 				return safeActionFn(input as S extends Schema ? InferIn<S> : undefined)
 					.then((res) => setResult(res ?? EMPTY_HOOK_RESULT))
 					.catch((e) => {
@@ -246,7 +247,7 @@ export const useOptimisticAction = <
 					});
 			});
 		},
-		[safeActionFn, setOptimisticData]
+		[safeActionFn, setOptimisticState]
 	);
 
 	const reset = () => {
@@ -271,7 +272,7 @@ export const useOptimisticAction = <
 		execute,
 		input: clientInput,
 		result,
-		optimisticData,
+		optimisticState,
 		reset,
 		status,
 		...getActionShorthandStatusObject(status),


### PR DESCRIPTION
This PR improves the design of the `useOptimisticAction` hook. Previously, the `optimisticData`  had to be of the same type of action's return type. This isn't great, because the only job of a Server Action in a optimistic workflow is to mutate the data on the server. The actual state (and type) that matters is the one coming from the parent Server Component, so `updateFn`'s `prevState` should match that type. The actual result is still available in hooks callbacks and `result` property returned from the hook,  though.

## Related issue(s) or discussion(s)

re #127