### PR TITLE
feat: support setting default validation errors shape per instance

### DIFF
--- a/apps/playground/src/app/(examples)/direct/login-action.ts
+++ b/apps/playground/src/app/(examples)/direct/login-action.ts
@@ -17,7 +17,8 @@ export const loginUser = action
 	.schema(schema, {
 		// Here we use the `flattenValidationErrors` function to customize the returned validation errors
 		// object to the client.
-		formatValidationErrors: (ve) => flattenValidationErrors(ve).fieldErrors,
+		handleValidationErrorsShape: (ve) =>
+			flattenValidationErrors(ve).fieldErrors,
 	})
 	.action(async ({ parsedInput: { username, password } }) => {
 		if (username === "johndoe") {

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -17,8 +17,8 @@ import { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE, isError, zodValidate
 import { ActionServerValidationError, buildValidationErrors } from "./validation-errors";
 import type {
 	BindArgsValidationErrors,
-	FormatBindArgsValidationErrorsFn,
-	FormatValidationErrorsFn,
+	HandleBindArgsValidationErrorsShapeFn,
+	HandleValidationErrorsShapeFn,
 	ValidationErrors,
 } from "./validation-errors.types";
 
@@ -34,8 +34,8 @@ export function actionBuilder<
 >(args: {
 	schema?: S;
 	bindArgsSchemas?: BAS;
-	formatValidationErrors: FormatValidationErrorsFn<S, CVE>;
-	formatBindArgsValidationErrors: FormatBindArgsValidationErrorsFn<BAS, CBAVE>;
+	handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
+	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	metadataSchema: MetadataSchema;
 	metadata: MD;
 	handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any>["handleServerErrorLog"]>;
@@ -161,7 +161,7 @@ export function actionBuilder<
 											const validationErrors = buildValidationErrors<S>(parsedInput.issues);
 
 											middlewareResult.validationErrors = await Promise.resolve(
-												args.formatValidationErrors(validationErrors)
+												args.handleValidationErrorsShape(validationErrors)
 											);
 										}
 									}
@@ -170,7 +170,7 @@ export function actionBuilder<
 								// If there are bind args validation errors, format them and store them in the middleware result.
 								if (hasBindValidationErrors) {
 									middlewareResult.bindArgsValidationErrors = await Promise.resolve(
-										args.formatBindArgsValidationErrors(bindArgsValidationErrors as BindArgsValidationErrors<BAS>)
+										args.handleBindArgsValidationErrorsShape(bindArgsValidationErrors as BindArgsValidationErrors<BAS>)
 									);
 								}
 
@@ -214,7 +214,7 @@ export function actionBuilder<
 							// If error is `ActionServerValidationError`, return `validationErrors` as if schema validation would fail.
 							if (e instanceof ActionServerValidationError) {
 								const ve = e.validationErrors as ValidationErrors<S>;
-								middlewareResult.validationErrors = await Promise.resolve(args.formatValidationErrors(ve));
+								middlewareResult.validationErrors = await Promise.resolve(args.handleValidationErrorsShape(ve));
 							} else {
 								// If error is not an instance of Error, wrap it in an Error object with
 								// the default message.

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -38,8 +38,8 @@ export function actionBuilder<
 	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	metadataSchema: MetadataSchema;
 	metadata: MD;
-	handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any>["handleServerErrorLog"]>;
-	handleReturnedServerError: NonNullable<SafeActionClientOpts<ServerError, any>["handleReturnedServerError"]>;
+	handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any, any>["handleServerErrorLog"]>;
+	handleReturnedServerError: NonNullable<SafeActionClientOpts<ServerError, any, any>["handleReturnedServerError"]>;
 	middlewareFns: MiddlewareFn<ServerError, any, any, any>[];
 	ctxType: Ctx;
 	validationStrategy: "typeschema" | "zod";

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -30,7 +30,7 @@ export type * from "./validation-errors.types";
  * {@link https://next-safe-action.dev/docs/safe-action-client/initialization-options See docs for more information}
  */
 export const createSafeActionClient = <
-	const ODVES extends DVES,
+	ODVES extends DVES | undefined = undefined,
 	ServerError = string,
 	MetadataSchema extends Schema | undefined = undefined,
 >(

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -2,13 +2,16 @@ import type { Infer, InferIn, Schema } from "@typeschema/main";
 import type { InferArray, InferInArray, MaybePromise, Prettify } from "./utils";
 import type { BindArgsValidationErrors, ValidationErrors } from "./validation-errors.types";
 
+export type DVES = "formatted" | "flattened";
+
 /**
  * Type of options when creating a new safe action client.
  */
-export type SafeActionClientOpts<ServerError, MetadataSchema extends Schema | undefined> = {
+export type SafeActionClientOpts<ServerError, MetadataSchema extends Schema | undefined, ODVES extends DVES> = {
 	handleServerErrorLog?: (e: Error) => MaybePromise<void>;
 	handleReturnedServerError?: (e: Error) => MaybePromise<ServerError>;
 	defineMetadataSchema?: () => MetadataSchema;
+	defaultValidationErrorsShape?: ODVES;
 };
 
 /**

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -2,6 +2,10 @@ import type { Infer, InferIn, Schema } from "@typeschema/main";
 import type { InferArray, InferInArray, MaybePromise, Prettify } from "./utils";
 import type { BindArgsValidationErrors, ValidationErrors } from "./validation-errors.types";
 
+/**
+ * Type of the default validation errors shape passed to `createSafeActionClient` via `defaultValidationErrorsShape`
+ * property.
+ */
 export type DVES = "formatted" | "flattened";
 
 /**

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -11,7 +11,11 @@ export type DVES = "formatted" | "flattened";
 /**
  * Type of options when creating a new safe action client.
  */
-export type SafeActionClientOpts<ServerError, MetadataSchema extends Schema | undefined, ODVES extends DVES> = {
+export type SafeActionClientOpts<
+	ServerError,
+	MetadataSchema extends Schema | undefined,
+	ODVES extends DVES | undefined,
+> = {
 	handleServerErrorLog?: (e: Error) => MaybePromise<void>;
 	handleReturnedServerError?: (e: Error) => MaybePromise<ServerError>;
 	defineMetadataSchema?: () => MetadataSchema;

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -13,7 +13,7 @@ import type {
 
 export class SafeActionClient<
 	ServerError,
-	const ODVES extends DVES,
+	ODVES extends DVES | undefined,
 	MetadataSchema extends Schema | undefined = undefined,
 	MD = MetadataSchema extends Schema ? Infer<Schema> : undefined,
 	Ctx = undefined,
@@ -23,9 +23,9 @@ export class SafeActionClient<
 	const CBAVE = undefined,
 > {
 	readonly #validationStrategy: "typeschema" | "zod";
-	readonly #handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any, ODVES>["handleServerErrorLog"]>;
+	readonly #handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any, any>["handleServerErrorLog"]>;
 	readonly #handleReturnedServerError: NonNullable<
-		SafeActionClientOpts<ServerError, any, ODVES>["handleReturnedServerError"]
+		SafeActionClientOpts<ServerError, any, any>["handleReturnedServerError"]
 	>;
 	readonly #middlewareFns: MiddlewareFn<ServerError, any, any, any>[];
 	readonly #ctxType = undefined as Ctx;
@@ -48,9 +48,11 @@ export class SafeActionClient<
 			handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
 			handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 			ctxType: Ctx;
-			defaultValidationErrorsShape: ODVES;
 		} & Required<
-			Pick<SafeActionClientOpts<ServerError, any, ODVES>, "handleReturnedServerError" | "handleServerErrorLog">
+			Pick<
+				SafeActionClientOpts<ServerError, any, ODVES>,
+				"handleReturnedServerError" | "handleServerErrorLog" | "defaultValidationErrorsShape"
+			>
 		>
 	) {
 		this.#middlewareFns = opts.middlewareFns;

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -1,36 +1,41 @@
 import type { Infer, Schema } from "@typeschema/main";
 import type {} from "zod";
 import { actionBuilder } from "./action-builder";
-import type { MiddlewareFn, SafeActionClientOpts, ServerCodeFn, StateServerCodeFn } from "./index.types";
+import type { DVES, MiddlewareFn, SafeActionClientOpts, ServerCodeFn, StateServerCodeFn } from "./index.types";
 import type {
 	BindArgsValidationErrors,
-	FormatBindArgsValidationErrorsFn,
-	FormatValidationErrorsFn,
+	FlattenedBindArgsValidationErrors,
+	FlattenedValidationErrors,
+	HandleBindArgsValidationErrorsShapeFn,
+	HandleValidationErrorsShapeFn,
 	ValidationErrors,
 } from "./validation-errors.types";
 
 export class SafeActionClient<
 	ServerError,
+	const ODVES extends DVES,
 	MetadataSchema extends Schema | undefined = undefined,
 	MD = MetadataSchema extends Schema ? Infer<Schema> : undefined,
 	Ctx = undefined,
 	S extends Schema | undefined = undefined,
 	const BAS extends readonly Schema[] = [],
-	CVE = ValidationErrors<S>,
-	const CBAVE = BindArgsValidationErrors<BAS>,
+	CVE = undefined,
+	const CBAVE = undefined,
 > {
-	readonly #handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any>["handleServerErrorLog"]>;
-	readonly #handleReturnedServerError: NonNullable<SafeActionClientOpts<ServerError, any>["handleReturnedServerError"]>;
 	readonly #validationStrategy: "typeschema" | "zod";
-
-	#middlewareFns: MiddlewareFn<ServerError, any, any, any>[];
-	#ctxType = undefined as Ctx;
-	#metadataSchema: MetadataSchema;
-	#metadata: MD;
-	#schema: S;
-	#bindArgsSchemas: BAS;
-	#formatValidationErrorsFn: FormatValidationErrorsFn<S, CVE>;
-	#formatBindArgsValidationErrorsFn: FormatBindArgsValidationErrorsFn<BAS, CBAVE>;
+	readonly #handleServerErrorLog: NonNullable<SafeActionClientOpts<ServerError, any, ODVES>["handleServerErrorLog"]>;
+	readonly #handleReturnedServerError: NonNullable<
+		SafeActionClientOpts<ServerError, any, ODVES>["handleReturnedServerError"]
+	>;
+	readonly #middlewareFns: MiddlewareFn<ServerError, any, any, any>[];
+	readonly #ctxType = undefined as Ctx;
+	readonly #metadataSchema: MetadataSchema;
+	readonly #metadata: MD;
+	readonly #schema: S;
+	readonly #bindArgsSchemas: BAS;
+	readonly #handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
+	readonly #handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
+	readonly #defaultValidationErrorsShape: ODVES;
 
 	constructor(
 		opts: {
@@ -40,10 +45,13 @@ export class SafeActionClient<
 			metadata: MD;
 			schema: S;
 			bindArgsSchemas: BAS;
-			formatValidationErrorsFn: FormatValidationErrorsFn<S, CVE>;
-			formatBindArgsValidationErrorsFn: FormatBindArgsValidationErrorsFn<BAS, CBAVE>;
+			handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
+			handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 			ctxType: Ctx;
-		} & Required<Pick<SafeActionClientOpts<ServerError, any>, "handleReturnedServerError" | "handleServerErrorLog">>
+			defaultValidationErrorsShape: ODVES;
+		} & Required<
+			Pick<SafeActionClientOpts<ServerError, any, ODVES>, "handleReturnedServerError" | "handleServerErrorLog">
+		>
 	) {
 		this.#middlewareFns = opts.middlewareFns;
 		this.#handleServerErrorLog = opts.handleServerErrorLog;
@@ -53,8 +61,9 @@ export class SafeActionClient<
 		this.#metadata = opts.metadata;
 		this.#schema = (opts.schema ?? undefined) as S;
 		this.#bindArgsSchemas = opts.bindArgsSchemas ?? [];
-		this.#formatValidationErrorsFn = opts.formatValidationErrorsFn;
-		this.#formatBindArgsValidationErrorsFn = opts.formatBindArgsValidationErrorsFn;
+		this.#handleValidationErrorsShape = opts.handleValidationErrorsShape;
+		this.#handleBindArgsValidationErrorsShape = opts.handleBindArgsValidationErrorsShape;
+		this.#defaultValidationErrorsShape = opts.defaultValidationErrorsShape;
 	}
 
 	/**
@@ -73,9 +82,10 @@ export class SafeActionClient<
 			metadata: this.#metadata,
 			schema: this.#schema,
 			bindArgsSchemas: this.#bindArgsSchemas,
-			formatValidationErrorsFn: this.#formatValidationErrorsFn,
-			formatBindArgsValidationErrorsFn: this.#formatBindArgsValidationErrorsFn,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as NextCtx,
+			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 		});
 	}
 
@@ -95,9 +105,10 @@ export class SafeActionClient<
 			metadata: data,
 			schema: this.#schema,
 			bindArgsSchemas: this.#bindArgsSchemas,
-			formatValidationErrorsFn: this.#formatValidationErrorsFn,
-			formatBindArgsValidationErrorsFn: this.#formatBindArgsValidationErrorsFn,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as Ctx,
+			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 		});
 	}
 
@@ -108,10 +119,13 @@ export class SafeActionClient<
 	 *
 	 * {@link https://next-safe-action.dev/docs/safe-action-client/instance-methods#schema See docs for more information}
 	 */
-	schema<OS extends Schema, OCVE = ValidationErrors<OS>>(
+	schema<
+		OS extends Schema,
+		OCVE = ODVES extends "flattened" ? FlattenedValidationErrors<ValidationErrors<OS>> : ValidationErrors<OS>,
+	>(
 		schema: OS,
 		utils?: {
-			formatValidationErrors?: FormatValidationErrorsFn<OS, OCVE>;
+			handleValidationErrorsShape?: HandleValidationErrorsShapeFn<OS, OCVE>;
 		}
 	) {
 		return new SafeActionClient({
@@ -123,10 +137,11 @@ export class SafeActionClient<
 			metadata: this.#metadata,
 			schema,
 			bindArgsSchemas: this.#bindArgsSchemas,
-			formatValidationErrorsFn: (utils?.formatValidationErrors ??
-				this.#formatValidationErrorsFn) as FormatValidationErrorsFn<OS, OCVE>,
-			formatBindArgsValidationErrorsFn: this.#formatBindArgsValidationErrorsFn,
+			handleValidationErrorsShape: (utils?.handleValidationErrorsShape ??
+				this.#handleValidationErrorsShape) as HandleValidationErrorsShapeFn<OS, OCVE>,
+			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as Ctx,
+			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 		});
 	}
 
@@ -137,9 +152,14 @@ export class SafeActionClient<
 	 *
 	 * {@link https://next-safe-action.dev/docs/safe-action-client/instance-methods#schema See docs for more information}
 	 */
-	bindArgsSchemas<const OBAS extends readonly Schema[], OCBAVE = BindArgsValidationErrors<OBAS>>(
+	bindArgsSchemas<
+		const OBAS extends readonly Schema[],
+		OCBAVE = ODVES extends "flattened"
+			? FlattenedBindArgsValidationErrors<BindArgsValidationErrors<OBAS>>
+			: BindArgsValidationErrors<OBAS>,
+	>(
 		bindArgsSchemas: OBAS,
-		utils?: { formatBindArgsValidationErrors?: FormatBindArgsValidationErrorsFn<OBAS, OCBAVE> }
+		utils?: { handleBindArgsValidationErrorsShape?: HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE> }
 	) {
 		return new SafeActionClient({
 			middlewareFns: this.#middlewareFns,
@@ -150,10 +170,11 @@ export class SafeActionClient<
 			metadata: this.#metadata,
 			schema: this.#schema,
 			bindArgsSchemas,
-			formatValidationErrorsFn: this.#formatValidationErrorsFn,
-			formatBindArgsValidationErrorsFn: (utils?.formatBindArgsValidationErrors ??
-				this.#formatBindArgsValidationErrorsFn) as FormatBindArgsValidationErrorsFn<OBAS, OCBAVE>,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: (utils?.handleBindArgsValidationErrorsShape ??
+				this.#handleBindArgsValidationErrorsShape) as HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE>,
 			ctxType: undefined as Ctx,
+			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 		});
 	}
 
@@ -174,8 +195,8 @@ export class SafeActionClient<
 			metadata: this.#metadata,
 			schema: this.#schema,
 			bindArgsSchemas: this.#bindArgsSchemas,
-			formatValidationErrors: this.#formatValidationErrorsFn,
-			formatBindArgsValidationErrors: this.#formatBindArgsValidationErrorsFn,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 		}).action(serverCodeFn);
 	}
 
@@ -197,8 +218,8 @@ export class SafeActionClient<
 			metadata: this.#metadata,
 			schema: this.#schema,
 			bindArgsSchemas: this.#bindArgsSchemas,
-			formatValidationErrors: this.#formatValidationErrorsFn,
-			formatBindArgsValidationErrors: this.#formatBindArgsValidationErrorsFn,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 		}).stateAction(serverCodeFn);
 	}
 }

--- a/packages/next-safe-action/src/typeschema.ts
+++ b/packages/next-safe-action/src/typeschema.ts
@@ -30,7 +30,7 @@ export type * from "./validation-errors.types";
  * {@link https://next-safe-action.dev/docs/safe-action-client/initialization-options See docs for more information}
  */
 export const createSafeActionClient = <
-	const ODVES extends DVES,
+	ODVES extends DVES | undefined = undefined,
 	ServerError = string,
 	MetadataSchema extends Schema | undefined = undefined,
 >(

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -46,13 +46,13 @@ export type FlattenedBindArgsValidationErrors<BAVE extends readonly ValidationEr
 /**
  * Type of the function used to format validation errors.
  */
-export type FormatValidationErrorsFn<S extends Schema | undefined, CVE> = (
+export type HandleValidationErrorsShapeFn<S extends Schema | undefined, CVE> = (
 	validationErrors: ValidationErrors<S>
 ) => CVE;
 
 /**
  * Type of the function used to format bind arguments validation errors.
  */
-export type FormatBindArgsValidationErrorsFn<BAS extends readonly Schema[], CBAVE> = (
+export type HandleBindArgsValidationErrorsShapeFn<BAS extends readonly Schema[], CBAVE> = (
 	bindArgsValidationErrors: BindArgsValidationErrors<BAS>
 ) => CBAVE;

--- a/website/docs/migrations/v6-to-v7.md
+++ b/website/docs/migrations/v6-to-v7.md
@@ -133,7 +133,7 @@ next-safe-action v7 supports bind arguments via the [`bindArgsSchemas`](/docs/sa
 
 As already said above, by default version 7 now returns validation errors in the same format of the Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method.
 
-This is customizable using the `formatValidationErrors`/`formatBindArgsValidationErrors` optional functions in `schema`/`bindArgsSchemas` methods. Check out [this page](/docs/recipes/customize-validation-errors-format) for more information. For instance, if you need to work with flattened errors (just like pre-v7), next-safe-action conveniently provides two functions to do that: [`flattenValidationErrors` and `flattenBindArgsValidationErrors`](/docs/recipes/customize-validation-errors-format#flattenvalidationerrors-and-flattenbindargsvalidationerrors-utility-functions).
+This is customizable using the `handleValidationErrorsShape`/`handleBindArgsValidationErrorsShape` optional functions in `schema`/`bindArgsSchemas` methods. Check out [this page](/docs/recipes/customize-validation-errors-format) for more information. For instance, if you need to work with flattened errors (just like pre-v7), next-safe-action conveniently provides two functions to do that: [`flattenValidationErrors` and `flattenBindArgsValidationErrors`](/docs/recipes/customize-validation-errors-format#flattenvalidationerrors-and-flattenbindargsvalidationerrors-utility-functions).
 
 ### [Allow calling `action` method without `schema`](https://github.com/TheEdoRan/next-safe-action/issues/107)
 

--- a/website/docs/migrations/v6-to-v7.md
+++ b/website/docs/migrations/v6-to-v7.md
@@ -129,11 +129,15 @@ Next.js allows you to [pass additional arguments to the action](https://nextjs.o
 
 next-safe-action v7 supports bind arguments via the [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) method.
 
+### [Support setting default validation errors shape per instance](https://github.com/TheEdoRan/next-safe-action/issues/153)
+
+By default, next-safe-action v7 returns validation errors in an object of the same shape as Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method. You can override this behavior globally by setting the [`defaultValidationErrorsShape`](/docs/safe-action-client/initialization-options#defaultvalidationerrorsshape) optional property to `flattened` in `createSafeActionClient` method. Doing so, the validation errors are returned in the shape of the Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method. If you need a custom format for a specific action, you can override the default shape using the `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions in `schema` and `bindArgsSchemas` methods, as explained below.
+
 ### [Support custom validation errors format](https://github.com/TheEdoRan/next-safe-action/issues/98)
 
 As already said above, by default version 7 now returns validation errors in the same format of the Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method.
 
-This is customizable using the `handleValidationErrorsShape`/`handleBindArgsValidationErrorsShape` optional functions in `schema`/`bindArgsSchemas` methods. Check out [this page](/docs/recipes/customize-validation-errors-format) for more information. For instance, if you need to work with flattened errors (just like pre-v7), next-safe-action conveniently provides two functions to do that: [`flattenValidationErrors` and `flattenBindArgsValidationErrors`](/docs/recipes/customize-validation-errors-format#flattenvalidationerrors-and-flattenbindargsvalidationerrors-utility-functions).
+This is customizable by using the `handleValidationErrorsShape`/`handleBindArgsValidationErrorsShape` optional functions in `schema`/`bindArgsSchemas` methods. Check out [this page](/docs/recipes/customize-validation-errors-format) for more information. For example, if you need to work with flattened errors for a specific action, next-safe-action conveniently provides two functions to do that: [`flattenValidationErrors` and `flattenBindArgsValidationErrors`](/docs/recipes/customize-validation-errors-format#flattenvalidationerrors-and-flattenbindargsvalidationerrors-utility-functions).
 
 ### [Allow calling `action` method without `schema`](https://github.com/TheEdoRan/next-safe-action/issues/107)
 

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -7,7 +7,11 @@ description: Learn how to customize validation errors format returned to the cli
 
 next-safe-action, by default, emulates Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method for building both validation and bind args validation errors and return them to the client.
 
-This can be customized by using `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions in [`schema`](/docs/safe-action-client/instance-methods#schema) and [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) methods.
+This can be customized both at the safe action client level and at the action level by:
+- using [`defaultValidationErrorsShape`](/docs/safe-action-client/initialization-options#defaultvalidationerrorsshape) optional property in `createSafeActionClient`;
+- using `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions in [`schema`](/docs/safe-action-client/instance-methods#schema) and [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) methods.
+
+The second way overrides the shape set at the instance level, per action. More information below.
 
 For example, if you want to flatten the validation errors (emulation of Zod's [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method), you can (but not required to) use the `flattenValidationErrors` utility function exported from the library, combining it with `handleValidationErrorsShape` inside `schema` method:
 
@@ -78,53 +82,3 @@ flattenedErrors = {
 ```
 
 `flattenBindArgsValidationErrors` works the same way, but with bind args (in [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) method), to build the validation errors array.
-
-### Flatten function for `schema` method
-
-next-safe-action, by default, uses the formatted validation errors structure, so errors for nested fields don't get discarded.
-
-If you need or want to flatten validation errors often, though, you can define an utility function like this one (assuming you're using Zod, but you can adapt it to your needs):
-
-```typescript title="src/lib/safe-action.ts"
-import { flattenValidationErrors, type HandleValidationErrorsShapeFn } from "next-safe-action";
-
-// ...
-
-export function fve<S extends z.ZodTypeAny>(schema: S): [
-  S,
-  {
-    handleValidationErrorsShape: HandleValidationErrorsShapeFn<
-      S,
-      FlattenedValidationErrors<ValidationErrors<S>>
-    >;
-  },
-] {
-  return [
-    schema,
-    {
-      handleValidationErrorsShape: (ve: ValidationErrors<S>) =>
-        flattenValidationErrors(ve),
-    },
-  ];
-}
-```
-
-That can then be used in [`schema`](/docs/safe-action-client/instance-methods#schema) method:
-
-```typescript src="src/app/login-action.ts"
-import { actionClient, fve } from "@/lib/safe-action";
-import { z } from "zod";
-
-const schema = z.object({
-  username: z.string().min(3).max(30),
-});
-
-const loginUser = actionClient
-  // Spread `fve` utility function in the `schema` method. Type safety is preserved.
-  .schema(...fve(schema))
-  .action(async ({ parsedInput: { username } }) => {
-    return {
-      greeting: `Welcome back, ${username}!`,
-    };
-  });
-```

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -7,9 +7,9 @@ description: Learn how to customize validation errors format returned to the cli
 
 next-safe-action, by default, emulates Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method for building both validation and bind args validation errors and return them to the client.
 
-This can be customized by using `formatValidationErrors` and `formatBindArgsValidationErrors` optional functions in [`schema`](/docs/safe-action-client/instance-methods#schema) and [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) methods.
+This can be customized by using `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions in [`schema`](/docs/safe-action-client/instance-methods#schema) and [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) methods.
 
-For example, if you want to flatten the validation errors (emulation of Zod's [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method), you can (but not required to) use the `flattenValidationErrors` utility function exported from the library, combining it with `formatValidationErrors` inside `schema` method:
+For example, if you want to flatten the validation errors (emulation of Zod's [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method), you can (but not required to) use the `flattenValidationErrors` utility function exported from the library, combining it with `handleValidationErrorsShape` inside `schema` method:
 
 ```typescript src="src/app/login-action.ts"
 "use server";
@@ -32,12 +32,12 @@ export const loginUser = actionClient
   .schema(schema, {
     // Here we use the `flattenValidationErrors` function to customize the returned validation errors
     // object to the client.
-    formatValidationErrors: (ve) => flattenValidationErrors(ve).fieldErrors,
+    handleValidationErrorsShape: (ve) => flattenValidationErrors(ve).fieldErrors,
   })
   .bindArgs(bindArgsSchemas, {
     // Here we use the `flattenBindArgsValidatonErrors` function to customize the returned bind args
     // validation errors object array to the client.
-    formatBindArgsValidationErrors: (ve) => flattenBindArgsValidationErrors(ve),
+    handleBindArgsValidationErrors: (ve) => flattenBindArgsValidationErrors(ve),
   })
   .action(async ({ parsedInput: { username, password } }) => {
     // Your code here...
@@ -86,14 +86,14 @@ next-safe-action, by default, uses the formatted validation errors structure, so
 If you need or want to flatten validation errors often, though, you can define an utility function like this one (assuming you're using Zod, but you can adapt it to your needs):
 
 ```typescript title="src/lib/safe-action.ts"
-import { flattenValidationErrors } from "next-safe-action";
+import { flattenValidationErrors, type HandleValidationErrorsShapeFn } from "next-safe-action";
 
 // ...
 
 export function fve<S extends z.ZodTypeAny>(schema: S): [
   S,
   {
-    formatValidationErrors: FormatValidationErrorsFn<
+    handleValidationErrorsShape: HandleValidationErrorsShapeFn<
       S,
       FlattenedValidationErrors<ValidationErrors<S>>
     >;
@@ -102,7 +102,7 @@ export function fve<S extends z.ZodTypeAny>(schema: S): [
   return [
     schema,
     {
-      formatValidationErrors: (ve: ValidationErrors<S>) =>
+      handleValidationErrorsShape: (ve: ValidationErrors<S>) =>
         flattenValidationErrors(ve),
     },
   ];

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -85,4 +85,4 @@ flattenedErrors = {
 
 ### `formatValidationErrors` and `formatBindArgsValidationErrors` utility functions
 
-These functions emulate Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method for building validation and bind args validation errors and return them to the client. You can use them, for instance, if you set the [`defaultValidationErrorsShape`](/docs/safe-action-client/initialization-options#defaultvalidationerrorsshape) to `flattened` in `createSafeActionClient`.
+These functions emulate Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method for building validation and bind args validation errors and return them to the client. You can use them, for instance, if you set the [`defaultValidationErrorsShape`](/docs/safe-action-client/initialization-options#defaultvalidationerrorsshape) to `flattened` in `createSafeActionClient` and need the formatted shape for a specific action.

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -82,3 +82,7 @@ flattenedErrors = {
 ```
 
 `flattenBindArgsValidationErrors` works the same way, but with bind args (in [`bindArgsSchemas`](/docs/safe-action-client/instance-methods#bindargsschemas) method), to build the validation errors array.
+
+### `formatValidationErrors` and `formatBindArgsValidationErrors` utility functions
+
+These functions emulate Zod's [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method for building validation and bind args validation errors and return them to the client. You can use them, for instance, if you set the [`defaultValidationErrorsShape`](/docs/safe-action-client/initialization-options#defaultvalidationerrorsshape) to `flattened` in `createSafeActionClient`.

--- a/website/docs/safe-action-client/initialization-options.md
+++ b/website/docs/safe-action-client/initialization-options.md
@@ -106,7 +106,7 @@ export const actionClient = createSafeActionClient({
 
 ## `defaultValidationErrorsShape?`
 
-You can provide this optional property to `createSafeActionClient` to specify the default shape of the validation errors. The two possible values are `flattened` and `formatted`. The first one emulates Zod [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method, the second one emulates Zod [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method, both for `validationErrors` and `bindArgsValidationErrors`. You can override the default shape in `schema` and `bindArgsSchemas` methods, more information about that [here](/docs/recipes/customize-validation-errors-format). If this property is not provided, the default shape is `formatted`, as it catches errors even in nested objects.
+You can provide this optional property to `createSafeActionClient` to specify the default shape of the validation errors. The two possible values are `flattened` and `formatted`. The first one emulates Zod [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method, the second one emulates Zod [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method, both for `validationErrors` and `bindArgsValidationErrors`. You can override the default shape in `schema` and `bindArgsSchemas` methods, more information about that [here](/docs/recipes/customize-validation-errors-format). If this property is not provided, the default shape is `formatted`, as it also catches errors for nested schema objects.
 
 ```typescript
 import { createSafeActionClient } from "next-safe-action";

--- a/website/docs/safe-action-client/initialization-options.md
+++ b/website/docs/safe-action-client/initialization-options.md
@@ -103,3 +103,16 @@ export const actionClient = createSafeActionClient({
   },
 });
 ```
+
+## `defaultValidationErrorsShape?`
+
+You can provide this optional property to `createSafeActionClient` to specify the default shape of the validation errors. The two possible values are `flattened` and `formatted`. The first one emulates Zod [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method, the second one emulates Zod [`format`](https://zod.dev/ERROR_HANDLING?id=formatting-errors) method, both for `validationErrors` and `bindArgsValidationErrors`. You can override the default shape in `schema` and `bindArgsSchemas` methods, more information about that [here](/docs/recipes/customize-validation-errors-format). If this property is not provided, the default shape is `formatted`, as it catches errors even in nested objects.
+
+```typescript
+import { createSafeActionClient } from "next-safe-action";
+
+export const actionClient = createSafeActionClient({
+  // By default all actions will return validation errors in the `flattened` shape.
+  defaultValidationErrorsShape: "flattened",
+});
+```

--- a/website/docs/safe-action-client/instance-methods.md
+++ b/website/docs/safe-action-client/instance-methods.md
@@ -28,18 +28,18 @@ metadata(data: Metadata) => new SafeActionClient()
 ## `schema`
 
 ```typescript
-schema(schema: S, utils?: { formatValidationErrors?: FormatValidationErrorsFn } }) => new SafeActionClient()
+schema(schema: S, utils?: { handleValidationErrorsShape?: HandleValidationErrorsShapeFn } }) => new SafeActionClient()
 ```
 
-`schema` accepts an **optional** input schema of type `Schema` (from TypeSchema) and an optional `utils` object that accepts a [`formatValidationErrors`](/docs/recipes/customize-validation-errors-format) function. The schema is used to define the arguments that the safe action will receive, the optional [`formatValidationErrors`](/docs/recipes/customize-validation-errors-format) function is used to return a custom format for validation errors. If you don't pass an input schema, `parsedInput` and validation errors will be typed `undefined`, and `clientInput` will be typed `void`. It returns a new instance of the safe action client.
+`schema` accepts an **optional** input schema of type `Schema` (from TypeSchema) and an optional `utils` object that accepts a [`handleValidationErrorsShape`](/docs/recipes/customize-validation-errors-format) function. The schema is used to define the arguments that the safe action will receive, the optional [`handleValidationErrorsShape`](/docs/recipes/customize-validation-errors-format) function is used to return a custom format for validation errors. If you don't pass an input schema, `parsedInput` and validation errors will be typed `undefined`, and `clientInput` will be typed `void`. It returns a new instance of the safe action client.
 
 ## `bindArgsSchemas`
 
 ```typescript
-bindArgsSchemas(bindArgsSchemas: BAS, bindArgsUtils?: { formatBindArgsValidationErrors?: FormatBindArgsValidationErrorsFn }) => new SafeActionClient()
+bindArgsSchemas(bindArgsSchemas: BAS, bindArgsUtils?: { handleBindArgsValidationErrorsShape?: HandleBindArgsValidationErrorsShapeFn }) => new SafeActionClient()
 ```
 
-`bindArgsSchemas` accepts an array of bind input schemas of type `Schema[]` (from TypeSchema) and an optional `bindArgsUtils` object that accepts a `formatBindArgsValidationErrors` function. The schema is used to define the bind arguments that the safe action will receive, the optional `formatBindArgsValidationErrors` function is used to [return a custom format for bind arguments validation errors](/docs/recipes/customize-validation-errors-format). It returns a new instance of the safe action client.
+`bindArgsSchemas` accepts an array of bind input schemas of type `Schema[]` (from TypeSchema) and an optional `bindArgsUtils` object that accepts a `handleBindArgsValidationErrorsShape` function. The schema is used to define the bind arguments that the safe action will receive, the optional `handleBindArgsValidationErrorsShape` function is used to [return a custom format for bind arguments validation errors](/docs/recipes/customize-validation-errors-format). It returns a new instance of the safe action client.
 
 ## `action` / `stateAction`
 

--- a/website/docs/types.md
+++ b/website/docs/types.md
@@ -20,10 +20,15 @@ export type DVES = "flattened" | "formatted";
 Type of options when creating a new safe action client.
 
 ```typescript
-export type SafeActionClientOpts<ServerError, MetadataSchema extends Schema | undefined> = {
+export type SafeActionClientOpts<
+  ServerError,
+  MetadataSchema extends Schema | undefined,
+  ODVES extends DVES | undefined
+> = {
   handleServerErrorLog?: (e: Error) => MaybePromise<void>;
   handleReturnedServerError?: (e: Error) => MaybePromise<ServerError>;
   defineMetadataSchema?: () => MetadataSchema;
+  defaultValidationErrorsShape?: ODVES;
 };
 ```
 

--- a/website/docs/types.md
+++ b/website/docs/types.md
@@ -200,22 +200,22 @@ export type FlattenedBindArgsValidationErrors<BAVE extends readonly ValidationEr
 };
 ```
 
-### `FormatValidationErrorsFn`
+### `HandleValidationErrorsShapeFn`
 
-Type of the function used to format validation errors.
+Type of the function used to format validation errors to custom shape.
 
 ```typescript
-export type FormatValidationErrorsFn<S extends Schema | undefined, CVE> = (
+export type HandleValidationErrorsShapeFn<S extends Schema | undefined, CVE> = (
   validationErrors: ValidationErrors<S>
 ) => CVE;
 ```
 
-### `FormatBindArgsValidationErrorsFn`
+### `HandleBindArgsValidationErrorsShapeFn`
 
-Type of the function used to format bind arguments validation errors.
+Type of the function used to format bind arguments validation errors to custom shape.
 
 ```typescript
-export type FormatBindArgsValidationErrorsFn<BAS extends readonly Schema[], FBAVE> = (
+export type HandleBindArgsValidationErrorsShapeFn<BAS extends readonly Schema[], FBAVE> = (
   bindArgsValidationErrors: BindArgsValidationErrors<BAS>
 ) => FBAVE;
 ```

--- a/website/docs/types.md
+++ b/website/docs/types.md
@@ -7,6 +7,14 @@ description: List of next-safe-action types.
 
 ## /
 
+### `DVES`
+
+Type of the default validation errors shape passed to `createSafeActionClient` via `defaultValidationErrorsShape` property.
+
+```typescript
+export type DVES = "flattened" | "formatted";
+```
+
 ### `SafeActionClientOpts`
 
 Type of options when creating a new safe action client.


### PR DESCRIPTION
Code in this PR adds the support for setting a default validation errors shape (formatted or flattened) per-instance. The shape is then overridable in `schema` and `bindArgsSchemas` methods, using `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions.