### PR TITLE
refactor: add `ctx` and `metadata` props to action callbacks

### DIFF
--- a/packages/next-safe-action/src/__tests__/action-callbacks.test.ts
+++ b/packages/next-safe-action/src/__tests__/action-callbacks.test.ts
@@ -5,7 +5,17 @@ import { test } from "node:test";
 import { z } from "zod";
 import { DEFAULT_SERVER_ERROR_MESSAGE, createSafeActionClient, returnValidationErrors } from "..";
 
-const ac = createSafeActionClient();
+const ac = createSafeActionClient({
+	defineMetadataSchema() {
+		return z.object({
+			actionName: z.string(),
+		});
+	},
+})
+	.use(async ({ next }) => {
+		return next({ ctx: { foo: "bar" } });
+	})
+	.metadata({ actionName: "test" });
 
 test("action with no input schema and no server errors calls `onSuccess` and `onSettled` callbacks", async () => {
 	let executed = 0;
@@ -45,12 +55,14 @@ test("action with input schemas and no errors calls `onSuccess` and `onSettled` 
 				};
 			},
 			{
-				onSuccess: ({ clientInput, bindArgsClientInputs, parsedInput, bindArgsParsedInputs, data }) => {
+				onSuccess: ({ clientInput, bindArgsClientInputs, parsedInput, bindArgsParsedInputs, data, metadata, ctx }) => {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ clientInput, bindArgsClientInputs, parsedInput, bindArgsParsedInputs, data },
+						{ clientInput, bindArgsClientInputs, parsedInput, bindArgsParsedInputs, data, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							clientInput: inputs[2],
 							bindArgsClientInputs: inputs.slice(0, 2),
 							parsedInput: inputs[2],
@@ -64,12 +76,14 @@ test("action with input schemas and no errors calls `onSuccess` and `onSettled` 
 				onError: () => {
 					executed++; // should not be called
 				},
-				onSettled: ({ clientInput, bindArgsClientInputs, result }) => {
+				onSettled: ({ clientInput, bindArgsClientInputs, result, metadata, ctx }) => {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ clientInput, bindArgsClientInputs, result },
+						{ clientInput, bindArgsClientInputs, result, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							clientInput: inputs[2],
 							bindArgsClientInputs: inputs.slice(0, 2),
 							result: {
@@ -102,12 +116,14 @@ test("action with input schemas and server error calls `onError` and `onSettled`
 				onSuccess: () => {
 					executed++; // should not be called
 				},
-				onError({ error, clientInput, bindArgsClientInputs }) {
+				onError({ error, clientInput, bindArgsClientInputs, metadata, ctx }) {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ error, clientInput, bindArgsClientInputs },
+						{ error, clientInput, bindArgsClientInputs, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							error: {
 								serverError: DEFAULT_SERVER_ERROR_MESSAGE,
 							},
@@ -116,12 +132,14 @@ test("action with input schemas and server error calls `onError` and `onSettled`
 						}
 					);
 				},
-				onSettled({ clientInput, bindArgsClientInputs, result }) {
+				onSettled({ clientInput, bindArgsClientInputs, result, metadata, ctx }) {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ result, clientInput, bindArgsClientInputs },
+						{ result, clientInput, bindArgsClientInputs, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							result: {
 								serverError: DEFAULT_SERVER_ERROR_MESSAGE,
 							},
@@ -154,12 +172,14 @@ test("action with validation errors calls `onError` and `onSettled` callbacks wi
 				onSuccess: () => {
 					executed++; // should not be called
 				},
-				onError({ error, clientInput, bindArgsClientInputs }) {
+				onError({ error, clientInput, bindArgsClientInputs, metadata, ctx }) {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ error, clientInput, bindArgsClientInputs },
+						{ error, clientInput, bindArgsClientInputs, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							error: {
 								validationErrors: {
 									username: {
@@ -180,12 +200,14 @@ test("action with validation errors calls `onError` and `onSettled` callbacks wi
 						}
 					);
 				},
-				onSettled({ clientInput, bindArgsClientInputs, result }) {
+				onSettled({ clientInput, bindArgsClientInputs, result, metadata, ctx }) {
 					executed++;
 
 					assert.deepStrictEqual(
-						{ result, clientInput, bindArgsClientInputs },
+						{ result, clientInput, bindArgsClientInputs, metadata, ctx },
 						{
+							metadata: { actionName: "test" },
+							ctx: { foo: "bar" },
 							result: {
 								validationErrors: {
 									username: {
@@ -231,12 +253,14 @@ test("action with server validation error calls `onError` and `onSettled` callba
 			onSuccess: () => {
 				executed++; // should not be called
 			},
-			onError({ error, clientInput, bindArgsClientInputs }) {
+			onError({ error, clientInput, bindArgsClientInputs, metadata, ctx }) {
 				executed++;
 
 				assert.deepStrictEqual(
-					{ error, clientInput, bindArgsClientInputs },
+					{ error, clientInput, bindArgsClientInputs, metadata, ctx },
 					{
+						metadata: { actionName: "test" },
+						ctx: { foo: "bar" },
 						error: {
 							validationErrors: {
 								username: {
@@ -249,12 +273,14 @@ test("action with server validation error calls `onError` and `onSettled` callba
 					}
 				);
 			},
-			onSettled({ clientInput, bindArgsClientInputs, result }) {
+			onSettled({ clientInput, bindArgsClientInputs, result, metadata, ctx }) {
 				executed++;
 
 				assert.deepStrictEqual(
-					{ result, clientInput, bindArgsClientInputs },
+					{ result, clientInput, bindArgsClientInputs, metadata, ctx },
 					{
+						metadata: { actionName: "test" },
+						ctx: { foo: "bar" },
 						result: {
 							validationErrors: {
 								username: {

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -52,13 +52,13 @@ export function actionBuilder<
 	function buildAction({ withState }: { withState: false }): {
 		action: <Data>(
 			serverCodeFn: ServerCodeFn<MD, Ctx, S, BAS, Data>,
-			cb?: SafeActionCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
+			cb?: SafeActionCallbacks<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
 		) => SafeActionFn<ServerError, S, BAS, CVE, CBAVE, Data>;
 	};
 	function buildAction({ withState }: { withState: true }): {
 		action: <Data>(
 			serverCodeFn: StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>,
-			cb?: SafeActionCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
+			cb?: SafeActionCallbacks<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
 		) => SafeStateActionFn<ServerError, S, BAS, CVE, CBAVE, Data>;
 	};
 	function buildAction({ withState }: { withState: boolean }) {
@@ -67,7 +67,7 @@ export function actionBuilder<
 				serverCodeFn:
 					| ServerCodeFn<MD, Ctx, S, BAS, Data>
 					| StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>,
-				cb?: SafeActionCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
+				cb?: SafeActionCallbacks<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
 			) => {
 				return async (...clientInputs: unknown[]) => {
 					let prevCtx: unknown = undefined;
@@ -252,6 +252,8 @@ export function actionBuilder<
 						await Promise.resolve(
 							cb?.onSuccess?.({
 								data: undefined,
+								metadata: args.metadata,
+								ctx: prevCtx as Ctx,
 								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 								parsedInput: parsedInputDatas.at(-1) as S extends Schema ? Infer<S> : undefined,
@@ -263,6 +265,8 @@ export function actionBuilder<
 
 						await Promise.resolve(
 							cb?.onSettled?.({
+								metadata: args.metadata,
+								ctx: prevCtx as Ctx,
 								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 								result: {},
@@ -295,6 +299,8 @@ export function actionBuilder<
 
 						await Promise.resolve(
 							cb?.onSuccess?.({
+								metadata: args.metadata,
+								ctx: prevCtx as Ctx,
 								data: actionResult.data as Data,
 								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
@@ -307,6 +313,8 @@ export function actionBuilder<
 					} else {
 						await Promise.resolve(
 							cb?.onError?.({
+								metadata: args.metadata,
+								ctx: prevCtx as Ctx,
 								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 								error: actionResult,
@@ -317,6 +325,8 @@ export function actionBuilder<
 					// onSettled, if provided, is always executed.
 					await Promise.resolve(
 						cb?.onSettled?.({
+							metadata: args.metadata,
+							ctx: prevCtx as Ctx,
 							clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
 							bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 							result: actionResult,

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -129,6 +129,8 @@ export type StateServerCodeFn<
  */
 export type SafeActionCallbacks<
 	ServerError,
+	MD,
+	Ctx,
 	S extends Schema | undefined,
 	BAS extends readonly Schema[],
 	CVE,
@@ -137,6 +139,8 @@ export type SafeActionCallbacks<
 > = {
 	onSuccess?: (args: {
 		data?: Data;
+		metadata: MD;
+		ctx?: Ctx;
 		clientInput: S extends Schema ? InferIn<S> : undefined;
 		bindArgsClientInputs: InferInArray<BAS>;
 		parsedInput: S extends Schema ? Infer<S> : undefined;
@@ -146,11 +150,15 @@ export type SafeActionCallbacks<
 	}) => MaybePromise<void>;
 	onError?: (args: {
 		error: Prettify<Omit<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>, "data">>;
+		metadata: MD;
+		ctx?: Ctx;
 		clientInput: S extends Schema ? InferIn<S> : undefined;
 		bindArgsClientInputs: InferInArray<BAS>;
 	}) => MaybePromise<void>;
 	onSettled?: (args: {
 		result: Prettify<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>>;
+		metadata: MD;
+		ctx?: Ctx;
 		clientInput: S extends Schema ? InferIn<S> : undefined;
 		bindArgsClientInputs: InferInArray<BAS>;
 		hasRedirected: boolean;

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -199,7 +199,7 @@ export class SafeActionClient<
 	 */
 	action<Data>(
 		serverCodeFn: ServerCodeFn<MD, Ctx, S, BAS, Data>,
-		cb?: SafeActionCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
+		cb?: SafeActionCallbacks<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
 	) {
 		return actionBuilder({
 			validationStrategy: this.#validationStrategy,
@@ -226,7 +226,7 @@ export class SafeActionClient<
 	 */
 	stateAction<Data>(
 		serverCodeFn: StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>,
-		cb?: SafeActionCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
+		cb?: SafeActionCallbacks<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
 	) {
 		return actionBuilder({
 			validationStrategy: this.#validationStrategy,

--- a/website/docs/execution/action-callbacks.md
+++ b/website/docs/execution/action-callbacks.md
@@ -18,6 +18,8 @@ const action = actionClient
   }, {
     onSuccess: ({
       data,
+      ctx,
+      metadata,
       clientInput,
       bindArgsClientInputs,
       parsedInput,
@@ -25,8 +27,8 @@ const action = actionClient
       hasRedirected,
       hasNotFound,
     }) => {},
-    onError: ({ error, clientInput, bindArgsClientInputs }) => {},
-    onSettled: ({ result, clientInput, bindArgsClientInputs }) => {},
+    onError: ({ error, ctx, metadata, clientInput, bindArgsClientInputs }) => {},
+    onSettled: ({ result, ctx, metadata, clientInput, bindArgsClientInputs }) => {},
   });
 ```
 


### PR DESCRIPTION
This PR adds `ctx` and `metadata` props to `onSuccess`, `onError` and `onSettled` action callbacks.