### PR TITLE
chore(website): Fix 404 link

### DIFF
--- a/website/src/components/landing/getting-started.tsx
+++ b/website/src/components/landing/getting-started.tsx
@@ -10,8 +10,8 @@ export function GettingStarted() {
 					className="!no-underline hover:brightness-90 transition cursor-pointer rounded-lg mr-4 px-3 py-2 font-bold inline-flex items-center justify-center text-2xl bg-zinc-800 !text-zinc-100 dark:bg-zinc-100 dark:!text-zinc-900 w-64">
 					Getting started 🎉
 				</a>
-				<a
-					href="/docs/recipes/basic-implementation"
+				<a 
+					href="/docs/recipes/playground"
 					className="!no-underline hover:brightness-90 transition cursor-pointer rounded-lg mr-4 px-3 py-2 font-bold inline-flex items-center justify-center text-2xl bg-[#ffa024] !text-zinc-100 w-64">
 					Explore example ➡️
 				</a>


### PR DESCRIPTION
# Proposed changes

chore(website): Currently, the "Explore example" link on the homepage takes users to a 404 Not Found page. I have updated the link to take users to the Recipes -> Playground page instead.

## Related issue(s) or discussion(s)

N/A

---

- [X] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
