### PR TITLE
v7.1.0 - `throwValidationErrors` and schema extension

### DIFF
--- a/packages/next-safe-action/src/__tests__/happy-path.test.ts
+++ b/packages/next-safe-action/src/__tests__/happy-path.test.ts
@@ -77,6 +77,32 @@ test("action with input schema passed via async function and return data gives b
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
+test("action with input schema extended via async function and return data gives back an object with correct `data`", async () => {
+	const userId = "ed6f5b84-6bca-4d01-9a51-c3d0c49a7996";
+	const password = "password";
+
+	const action = ac
+		.schema(z.object({ password: z.string() }))
+		.schema(async (prevSchema) => prevSchema.extend({ userId: z.string().uuid() }))
+		.action(async ({ parsedInput }) => {
+			return {
+				userId: parsedInput.userId,
+				password: parsedInput.password,
+			};
+		});
+
+	const actualResult = await action({ password, userId });
+
+	const expectedResult = {
+		data: {
+			password,
+			userId,
+		},
+	};
+
+	assert.deepStrictEqual(actualResult, expectedResult);
+});
+
 test("action with no input schema, bind args input schemas and return data gives back an object with correct `data`", async () => {
 	const username = "johndoe";
 	const age = 30;

--- a/packages/next-safe-action/src/__tests__/typeschema/happy-path.test.ts
+++ b/packages/next-safe-action/src/__tests__/typeschema/happy-path.test.ts
@@ -77,6 +77,32 @@ test("typeschema - action with input schema passed via async function and return
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
+test("typeschema - action with input schema extended via async function and return data gives back an object with correct `data`", async () => {
+	const userId = "ed6f5b84-6bca-4d01-9a51-c3d0c49a7996";
+	const password = "password";
+
+	const action = ac
+		.schema(z.object({ password: z.string() }))
+		.schema(async (prevSchema) => prevSchema.extend({ userId: z.string().uuid() }))
+		.action(async ({ parsedInput }) => {
+			return {
+				userId: parsedInput.userId,
+				password: parsedInput.password,
+			};
+		});
+
+	const actualResult = await action({ password, userId });
+
+	const expectedResult = {
+		data: {
+			password,
+			userId,
+		},
+	};
+
+	assert.deepStrictEqual(actualResult, expectedResult);
+});
+
 test("typeschema - action with no input schema, bind args input schemas and return data gives back an object with correct `data`", async () => {
 	const username = "johndoe";
 	const age = 30;

--- a/packages/next-safe-action/src/__tests__/typeschema/validation-errors.test.ts
+++ b/packages/next-safe-action/src/__tests__/typeschema/validation-errors.test.ts
@@ -538,3 +538,44 @@ test("typeschema - action with errors set via `returnValidationErrors` gives bac
 
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
+
+// `throwValidationErrors` tests.
+
+const tveac = createSafeActionClient({
+	throwValidationErrors: true,
+});
+
+test("typeschema - action with validation errors and `throwValidationErrors` option set to true in client throws", async () => {
+	const schema = z.object({
+		username: z.string().min(3),
+		password: z.string().min(3),
+	});
+
+	const action = tveac.schema(schema).action(async () => {
+		return {
+			ok: true,
+		};
+	});
+
+	assert.rejects(async () => await action({ username: "12", password: "34" }));
+});
+
+test("typeschema - action with server validation errors and `throwValidationErrors` option set to true in client throws", async () => {
+	const schema = z.object({
+		username: z.string().min(3),
+		password: z.string().min(3),
+	});
+
+	const action = tveac.schema(schema).action(async () => {
+		returnValidationErrors(schema, {
+			username: {
+				_errors: ["user_suspended"],
+			},
+		});
+		return {
+			ok: true,
+		};
+	});
+
+	assert.rejects(async () => await action({ username: "1234", password: "5678" }));
+});

--- a/packages/next-safe-action/src/__tests__/validation-errors.test.ts
+++ b/packages/next-safe-action/src/__tests__/validation-errors.test.ts
@@ -533,3 +533,44 @@ test("action with errors set via `returnValidationErrors` gives back an object w
 
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
+
+// `throwValidationErrors` tests.
+
+const tveac = createSafeActionClient({
+	throwValidationErrors: true,
+});
+
+test("action with validation errors and `throwValidationErrors` option set to true in client throws", async () => {
+	const schema = z.object({
+		username: z.string().min(3),
+		password: z.string().min(3),
+	});
+
+	const action = tveac.schema(schema).action(async () => {
+		return {
+			ok: true,
+		};
+	});
+
+	assert.rejects(async () => await action({ username: "12", password: "34" }));
+});
+
+test("action with server validation errors and `throwValidationErrors` option set to true in client throws", async () => {
+	const schema = z.object({
+		username: z.string().min(3),
+		password: z.string().min(3),
+	});
+
+	const action = tveac.schema(schema).action(async () => {
+		returnValidationErrors(schema, {
+			username: {
+				_errors: ["user_suspended"],
+			},
+		});
+		return {
+			ok: true,
+		};
+	});
+
+	assert.rejects(async () => await action({ username: "1234", password: "5678" }));
+});

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -16,7 +16,7 @@ import type {
 } from "./index.types";
 import type { InferArray, InferInArray } from "./utils";
 import { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE, isError, zodValidate } from "./utils";
-import { buildValidationErrors } from "./validation-errors";
+import { ActionValidationError, buildValidationErrors } from "./validation-errors";
 import type {
 	BindArgsValidationErrors,
 	HandleBindArgsValidationErrorsShapeFn,
@@ -46,6 +46,7 @@ export function actionBuilder<
 	middlewareFns: MiddlewareFn<ServerError, any, any, any>[];
 	ctxType: Ctx;
 	validationStrategy: "typeschema" | "zod";
+	throwValidationErrors: boolean;
 }) {
 	const bindArgsSchemas = (args.bindArgsSchemas ?? []) as BAS;
 
@@ -281,6 +282,9 @@ export function actionBuilder<
 					const actionResult: SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data> = {};
 
 					if (typeof middlewareResult.validationErrors !== "undefined") {
+						if (args.throwValidationErrors) {
+							throw new ActionValidationError(middlewareResult.validationErrors as CVE);
+						}
 						actionResult.validationErrors = middlewareResult.validationErrors as CVE;
 					}
 

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -11,6 +11,7 @@ import {
 
 export { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
 export {
+	ActionValidationError,
 	flattenBindArgsValidationErrors,
 	flattenValidationErrors,
 	formatBindArgsValidationErrors,
@@ -63,6 +64,7 @@ export const createSafeActionClient = <
 		metadataSchema: createOpts?.defineMetadataSchema?.(),
 		metadata: undefined as MetadataSchema extends Schema ? Infer<MetadataSchema> : undefined,
 		defaultValidationErrorsShape: (createOpts?.defaultValidationErrorsShape ?? "formatted") as ODVES,
+		throwValidationErrors: Boolean(createOpts?.throwValidationErrors),
 		handleValidationErrorsShape:
 			createOpts?.defaultValidationErrorsShape === "flattened" ? flattenValidationErrors : formatValidationErrors,
 		handleBindArgsValidationErrorsShape:

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -19,6 +19,7 @@ export type SafeActionClientOpts<
 	handleServerErrorLog?: (e: Error) => MaybePromise<void>;
 	handleReturnedServerError?: (e: Error) => MaybePromise<ServerError>;
 	defineMetadataSchema?: () => MetadataSchema;
+	throwValidationErrors?: boolean;
 	defaultValidationErrorsShape?: ODVES;
 };
 

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -44,6 +44,7 @@ export class SafeActionClient<
 	readonly #handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
 	readonly #handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	readonly #defaultValidationErrorsShape: ODVES;
+	readonly #throwValidationErrors: boolean;
 
 	constructor(
 		opts: {
@@ -59,7 +60,7 @@ export class SafeActionClient<
 		} & Required<
 			Pick<
 				SafeActionClientOpts<ServerError, any, ODVES>,
-				"handleReturnedServerError" | "handleServerErrorLog" | "defaultValidationErrorsShape"
+				"handleReturnedServerError" | "handleServerErrorLog" | "defaultValidationErrorsShape" | "throwValidationErrors"
 			>
 		>
 	) {
@@ -74,6 +75,7 @@ export class SafeActionClient<
 		this.#handleValidationErrorsShape = opts.handleValidationErrorsShape;
 		this.#handleBindArgsValidationErrorsShape = opts.handleBindArgsValidationErrorsShape;
 		this.#defaultValidationErrorsShape = opts.defaultValidationErrorsShape;
+		this.#throwValidationErrors = opts.throwValidationErrors;
 	}
 
 	/**
@@ -96,6 +98,7 @@ export class SafeActionClient<
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as NextCtx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		});
 	}
 
@@ -119,6 +122,7 @@ export class SafeActionClient<
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		});
 	}
 
@@ -160,6 +164,7 @@ export class SafeActionClient<
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: undefined as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		});
 	}
 
@@ -193,6 +198,7 @@ export class SafeActionClient<
 				this.#handleBindArgsValidationErrorsShape) as HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE>,
 			ctxType: undefined as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		});
 	}
 
@@ -219,6 +225,7 @@ export class SafeActionClient<
 			bindArgsSchemas: this.#bindArgsSchemas,
 			handleValidationErrorsShape: this.#handleValidationErrorsShape,
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		}).action(serverCodeFn, cb);
 	}
 
@@ -246,6 +253,7 @@ export class SafeActionClient<
 			bindArgsSchemas: this.#bindArgsSchemas,
 			handleValidationErrorsShape: this.#handleValidationErrorsShape,
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
+			throwValidationErrors: this.#throwValidationErrors,
 		}).stateAction(serverCodeFn, cb);
 	}
 }

--- a/packages/next-safe-action/src/typeschema.ts
+++ b/packages/next-safe-action/src/typeschema.ts
@@ -11,6 +11,7 @@ import {
 
 export { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
 export {
+	ActionValidationError,
 	flattenBindArgsValidationErrors,
 	flattenValidationErrors,
 	formatBindArgsValidationErrors,
@@ -63,6 +64,7 @@ export const createSafeActionClient = <
 		metadataSchema: createOpts?.defineMetadataSchema?.(),
 		metadata: undefined as MetadataSchema extends Schema ? Infer<MetadataSchema> : undefined,
 		defaultValidationErrorsShape: (createOpts?.defaultValidationErrorsShape ?? "formatted") as ODVES,
+		throwValidationErrors: Boolean(createOpts?.throwValidationErrors),
 		handleValidationErrorsShape:
 			createOpts?.defaultValidationErrorsShape === "flattened" ? flattenValidationErrors : formatValidationErrors,
 		handleBindArgsValidationErrorsShape:

--- a/packages/next-safe-action/src/validation-errors.ts
+++ b/packages/next-safe-action/src/validation-errors.ts
@@ -56,9 +56,19 @@ export class ActionServerValidationError<S extends Schema> extends Error {
 	public kind: string;
 	public validationErrors: ValidationErrors<S>;
 	constructor(validationErrors: ValidationErrors<S>) {
-		super("Action server validation error");
+		super("Server Action server validation error(s) occurred");
 		this.validationErrors = validationErrors;
 		this.kind = "__actionServerValidationError";
+	}
+}
+
+// This class is internally used to throw validation errors in action's server code function, using
+// `returnValidationErrors`.
+export class ActionValidationError<CVE> extends Error {
+	public validationErrors: CVE;
+	constructor(validationErrors: CVE) {
+		super("Server Action validation error(s) occurred");
+		this.validationErrors = validationErrors;
 	}
 }
 

--- a/website/docs/recipes/additional-validation-errors.md
+++ b/website/docs/recipes/additional-validation-errors.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 description: Set additional custom validation errors in schema or in action's server code function.
 ---
 

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 description: Learn how to customize validation errors format returned to the client.
 ---
 

--- a/website/docs/recipes/customize-validation-errors-format.md
+++ b/website/docs/recipes/customize-validation-errors-format.md
@@ -48,6 +48,10 @@ export const loginUser = actionClient
   });
 ```
 
+:::note
+If you chain multiple `schema` methods, as explained in the [Extend previous schema](/docs/recipes/extend-previous-schema) page, and want to override the default validation errors shape, you **must** use `handleValidationErrorsShape` inside the last `schema` method, otherwise there would be a type mismatch in the returned action result.
+:::
+
 ### `flattenValidationErrors` and `flattenBindArgsValidationErrors` utility functions
 
 Exported `flattenValidationErrors` and `flattenBindArgsValidationErrors` utility functions emulates Zod's [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method for building validation errors and return them to the client. Be aware that they discard errors for nested fields in objects, but when dealing with simple one-level schemas, it's sometimes better to use the flattened format instead of the formatted one.

--- a/website/docs/recipes/extend-base-client.md
+++ b/website/docs/recipes/extend-base-client.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 description: Learn how to use both a basic and an authorization client at the same time in your project.
 ---
 
-# Extending a base client
+# Extend base client
 
 A common and recommended pattern with this library is to extend the base safe action client, to cover different use cases that you might want and/or need in your applicaton.
 

--- a/website/docs/recipes/extend-previous-schema.md
+++ b/website/docs/recipes/extend-previous-schema.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 3
+description: Learn how to use next-safe-action with a i18n solution.
+---
+
+# Extend previous schema
+
+Sometimes it's useful to define an action "template" with a base schema and then extend it with additional properties. This can be done inside the [`schema`](/docs/safe-action-client/instance-methods#schema) method by passing an async function that has the previous schema as its argument. See the example below:
+
+```typescript
+"use server";
+
+import { actionClient } from "@/lib/safe-action";
+import { z } from "zod";
+
+const schema = z.object({
+  username: z.string(),
+});
+
+const myAction = actionClient
+  .schema(schema)
+  .schema(async (prevSchema) => {
+    // Here we extend the previous schema with `password` property.
+    return prevSchema.extend({ password: z.string() });
+  })
+  .schema(async (prevSchema) => {
+    // Here with `age` property.
+    return prevSchema.extend({ age: z.number().positive() });
+  })
+  // `parsedInput` will be an object with `username`, `password` and `age` properties.
+  .action(async ({ parsedInput: { username, password, age } }) => { 
+    // Do something useful here...
+  });
+```
+
+Note that if you don't use `prevSchema` inside the `schema` method, the previous schema(s) will be overwritten.

--- a/website/docs/recipes/form-actions.md
+++ b/website/docs/recipes/form-actions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 description: Learn how to use next-safe-action with Form Actions.
 ---
 

--- a/website/docs/recipes/i18n.md
+++ b/website/docs/recipes/i18n.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 description: Learn how to use next-safe-action with a i18n solution.
 ---
 

--- a/website/docs/recipes/upload-files.md
+++ b/website/docs/recipes/upload-files.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 description: Learn how to upload a file using next-safe-action.
 ---
 

--- a/website/docs/safe-action-client/index.md
+++ b/website/docs/safe-action-client/index.md
@@ -5,6 +5,6 @@ description: Safe action client is the instance that you can use to create types
 
 # Safe action client
 
-The safe action client instance is created by the `createSafeActionClient()` function. The instance is used to create safe actions, as you have already seen in previous sections of the documentation. You can create multiple clients too, for different purposes, as explained [in this section](/docs/recipes/extending-base-client).
+The safe action client instance is created by the `createSafeActionClient()` function. The instance is used to create safe actions, as you have already seen in previous sections of the documentation. You can create multiple clients too, for different purposes, as explained [in this section](/docs/recipes/extend-base-client).
 
 You can also provide functions to the client, to customize the behavior for every action you then create with it. We will explore them in detail in the next sections.

--- a/website/docs/safe-action-client/initialization-options.md
+++ b/website/docs/safe-action-client/initialization-options.md
@@ -116,3 +116,7 @@ export const actionClient = createSafeActionClient({
   defaultValidationErrorsShape: "flattened",
 });
 ```
+
+## `throwValidationErrors?`
+
+You can provide this optional boolean property to `createSafeActionClient` to change the default behavior of what happens when validation errors occur during action execution. When this option is set to `true`, the action will throw a `ActionValidationError` with the related validation errors in a `validationErrors` property. This option also works for server validation errors set with [`returnValidationErrors`](/docs/recipes/additional-validation-errors#returnvalidationerrors) function. The errors shape respects the `defaultValidationErrorsShape` option or the overridden one set in [`schema`](/docs/safe-action-client/instance-methods#schema) using the optional [`handleValidationErrorsShape`](/docs/recipes/customize-validation-errors-format) function. The default value is `false`.


### PR DESCRIPTION
# Proposed changes

This PR adds the support for:
1. Throwing validation errors with a `throwValidationErrors` config option passed to `createSafeActionClient`;
2. Extend schema by adding a `prevSchema` argument to the function passed to `schema` method.

## Related issue(s) or discussion(s)

1. #171
2. #173
