### PR TITLE
chore(website): export `authActionClient` in middleware example

### DIFF
--- a/website/docs/safe-action-client/middleware.md
+++ b/website/docs/safe-action-client/middleware.md
@@ -62,7 +62,7 @@ const actionClient = createSafeActionClient({
 // Auth client defined by extending the base one.
 // Note that the same initialization options and middleware functions of the base client
 // will also be used for this one.
-const authActionClient = actionClient
+export const authActionClient = actionClient
   // Define authorization middleware.
   .use(async ({ next }) => {
     const session = cookies().get("session")?.value;


### PR DESCRIPTION
Since this is being imported to another file, its good idea to export it

# Proposed changes

Add `export` statement in example code 

