### PR TITLE
refactor(types): export infer utility types

### DIFF
--- a/packages/next-safe-action/src/hooks-utils.ts
+++ b/packages/next-safe-action/src/hooks-utils.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import {} from "react/experimental";
 import type {} from "zod";
 import type { InferIn, Schema } from "./adapters/types";
-import type { HookActionStatus, HookBaseUtils, HookCallbacks, HookResult } from "./hooks.types";
+import type { HookActionStatus, HookBaseUtils, HookCallbacks, HookResult, HookShorthandStatus } from "./hooks.types";
 
 export const getActionStatus = <
 	ServerError,
@@ -42,7 +42,7 @@ export const getActionShorthandStatusObject = ({
 }: {
 	status: HookActionStatus;
 	isTransitioning: boolean;
-}) => {
+}): HookShorthandStatus => {
 	return {
 		isIdle: status === "idle",
 		isExecuting: status === "executing",

--- a/packages/next-safe-action/src/hooks.ts
+++ b/packages/next-safe-action/src/hooks.ts
@@ -7,7 +7,14 @@ import {} from "react/experimental";
 import type {} from "zod";
 import type { InferIn, Schema } from "./adapters/types";
 import { getActionShorthandStatusObject, getActionStatus, useActionCallbacks, useExecuteOnMount } from "./hooks-utils";
-import type { HookBaseUtils, HookCallbacks, HookResult, HookSafeActionFn } from "./hooks.types";
+import type {
+	HookBaseUtils,
+	HookCallbacks,
+	HookResult,
+	HookSafeActionFn,
+	UseActionHookReturn,
+	UseOptimisticActionHookReturn,
+} from "./hooks.types";
 import { isError } from "./utils";
 
 // HOOKS
@@ -29,7 +36,7 @@ export const useAction = <
 >(
 	safeActionFn: HookSafeActionFn<ServerError, S, BAS, CVE, CBAVE, Data>,
 	utils?: HookBaseUtils<S> & HookCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
-) => {
+): UseActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data> => {
 	const [isTransitioning, startTransition] = React.useTransition();
 	const [result, setResult] = React.useState<HookResult<ServerError, S, BAS, CVE, CBAVE, Data>>({});
 	const [clientInput, setClientInput] = React.useState<S extends Schema ? InferIn<S> : void>();
@@ -124,7 +131,7 @@ export const useAction = <
 	return {
 		execute,
 		executeAsync,
-		input: clientInput,
+		input: clientInput as S extends Schema ? InferIn<S> : undefined,
 		result,
 		reset,
 		status,
@@ -154,7 +161,7 @@ export const useOptimisticAction = <
 		updateFn: (state: State, input: S extends Schema ? InferIn<S> : undefined) => State;
 	} & HookBaseUtils<S> &
 		HookCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
-) => {
+): UseOptimisticActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data, State> => {
 	const [isTransitioning, startTransition] = React.useTransition();
 	const [result, setResult] = React.useState<HookResult<ServerError, S, BAS, CVE, CBAVE, Data>>({});
 	const [clientInput, setClientInput] = React.useState<S extends Schema ? InferIn<S> : void>();
@@ -255,7 +262,7 @@ export const useOptimisticAction = <
 	return {
 		execute,
 		executeAsync,
-		input: clientInput,
+		input: clientInput as S extends Schema ? InferIn<S> : undefined,
 		result,
 		optimisticState,
 		reset,

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -1,5 +1,5 @@
 import type { InferIn, Schema } from "./adapters/types";
-import type { SafeActionResult } from "./index.types";
+import type { SafeActionFn, SafeActionResult, SafeStateActionFn } from "./index.types";
 import type { MaybePromise, Prettify } from "./utils.types";
 
 /**
@@ -147,3 +147,48 @@ export type UseStateActionHookReturn<
 	CBAVE,
 	Data,
 > = Omit<UseActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data>, "executeAsync" | "reset"> & HookShorthandStatus;
+
+/**
+ * Type of the return object of the `useAction` hook.
+ */
+export type InferUseActionHookReturn<T extends Function> =
+	T extends SafeActionFn<
+		infer ServerError,
+		infer S extends Schema | undefined,
+		infer BAS extends readonly Schema[],
+		infer CVE,
+		infer CBAVE,
+		infer Data
+	>
+		? UseActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data>
+		: never;
+
+/**
+ * Type of the return object of the `useOptimisticAction` hook.
+ */
+export type InferUseOptimisticActionHookReturn<T extends Function, State = any> =
+	T extends SafeActionFn<
+		infer ServerError,
+		infer S extends Schema | undefined,
+		infer BAS extends readonly Schema[],
+		infer CVE,
+		infer CBAVE,
+		infer Data
+	>
+		? UseOptimisticActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data, State>
+		: never;
+
+/**
+ * Type of the return object of the `useStateAction` hook.
+ */
+export type InferUseStateActionHookReturn<T extends Function> =
+	T extends SafeStateActionFn<
+		infer ServerError,
+		infer S extends Schema | undefined,
+		infer BAS extends readonly Schema[],
+		infer CVE,
+		infer CBAVE,
+		infer Data
+	>
+		? UseStateActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data>
+		: never;

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -139,7 +139,7 @@ export type UseOptimisticActionHookReturn<
 /**
  * Type of the return object of the `useStateAction` hook.
  */
-export type UseStateActionReturn<
+export type UseStateActionHookReturn<
 	ServerError,
 	S extends Schema | undefined,
 	BAS extends readonly Schema[],

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -83,6 +83,67 @@ export type HookSafeStateActionFn<
 ) => Promise<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>>;
 
 /**
- * Type of the action status returned by `useAction` and `useOptimisticAction` hooks.
+ * Type of the action status returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.
  */
 export type HookActionStatus = "idle" | "executing" | "hasSucceeded" | "hasErrored";
+
+/**
+ * Type of the shorthand status object returned by `useAction`, `useOptimisticAction` and `useStateAction` hooks.
+ */
+export type HookShorthandStatus = {
+	isIdle: boolean;
+	isExecuting: boolean;
+	isTransitioning: boolean;
+	isPending: boolean;
+	hasSucceeded: boolean;
+	hasErrored: boolean;
+};
+
+/**
+ * Type of the return object of the `useAction` hook.
+ */
+export type UseActionHookReturn<
+	ServerError,
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	CVE,
+	CBAVE,
+	Data,
+> = {
+	execute: (input: S extends Schema ? InferIn<S> : void) => void;
+	executeAsync: (
+		input: S extends Schema ? InferIn<S> : void
+	) => Promise<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data> | undefined>;
+	input: S extends Schema ? InferIn<S> : undefined;
+	result: Prettify<HookResult<ServerError, S, BAS, CVE, CBAVE, Data>>;
+	reset: () => void;
+	status: HookActionStatus;
+} & HookShorthandStatus;
+
+/**
+ * Type of the return object of the `useOptimisticAction` hook.
+ */
+export type UseOptimisticActionHookReturn<
+	ServerError,
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	CVE,
+	CBAVE,
+	Data,
+	State,
+> = UseActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data> &
+	HookShorthandStatus & {
+		optimisticState: State;
+	};
+
+/**
+ * Type of the return object of the `useStateAction` hook.
+ */
+export type UseStateActionReturn<
+	ServerError,
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	CVE,
+	CBAVE,
+	Data,
+> = Omit<UseActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data>, "executeAsync" | "reset"> & HookShorthandStatus;

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -248,22 +248,28 @@ export type InferSafeActionFnResult<T extends Function> = T extends
 	: never;
 
 /**
- * Infer the context type of a safe action client.
- */
-export type InferSafeActionClientCtx<T> =
-	T extends SafeActionClient<any, any, any, any, infer Ctx extends object, any, any, any, any, any> ? Ctx : never;
-
-/**
- * Infer the metadata type of a safe action client.
- */
-export type InferSafeActionClientMetadata<T> =
-	T extends SafeActionClient<any, any, any, infer MD, any, any, any, any, any, any> ? MD : never;
-
-/**
  * Infer the next context type returned by a middleware function.
  */
 export type InferMiddlewareFnNextCtx<T> =
 	T extends MiddlewareFn<any, any, any, infer NextCtx extends object> ? NextCtx : never;
+
+/**
+ * Infer the context type of a safe action client or middleware function.
+ */
+export type InferCtx<T> = T extends
+	| SafeActionClient<any, any, any, any, infer Ctx extends object, any, any, any, any, any>
+	| MiddlewareFn<any, any, infer Ctx extends object, any>
+	? Ctx
+	: never;
+
+/**
+ * Infer the metadata type of a safe action client or middleware function.
+ */
+export type InferMetadata<T> = T extends
+	| SafeActionClient<any, any, any, infer MD, any, any, any, any, any, any>
+	| MiddlewareFn<any, infer MD, any, any>
+	? MD
+	: never;
 
 /**
  * Infer the server error type from a safe action client or a middleware function or a safe action function.

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -248,7 +248,7 @@ export type InferSafeActionFnResult<T extends Function> = T extends
 	: never;
 
 /**
- * Infer the next context type returned by a middleware function.
+ * Infer the next context type returned by a middleware function using the `next` function.
  */
 export type InferMiddlewareFnNextCtx<T> =
 	T extends MiddlewareFn<any, any, any, infer NextCtx extends object> ? NextCtx : never;

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -1,4 +1,5 @@
 import type { Infer, InferArray, InferIn, InferInArray, Schema, ValidationAdapter } from "./adapters/types";
+import type { SafeActionClient } from "./safe-action-client";
 import type { MaybePromise, Prettify } from "./utils.types";
 import type { BindArgsValidationErrors, ValidationErrors } from "./validation-errors.types";
 
@@ -201,3 +202,76 @@ export type SafeActionUtils<
 		hasNotFound: boolean;
 	}) => MaybePromise<void>;
 };
+
+/**
+ * Infer input types of a safe action.
+ */
+export type InferSafeActionFnInput<T extends Function> = T extends
+	| SafeActionFn<any, infer S extends Schema | undefined, infer BAS extends readonly Schema[], any, any, any>
+	| SafeStateActionFn<any, infer S extends Schema | undefined, infer BAS extends readonly Schema[], any, any, any>
+	? S extends Schema
+		? {
+				clientInput: InferIn<S>;
+				bindArgsClientInputs: InferInArray<BAS>;
+				parsedInput: Infer<S>;
+				bindArgsParsedInputs: InferArray<BAS>;
+			}
+		: {
+				clientInput: undefined;
+				bindArgsClientInputs: InferInArray<BAS>;
+				parsedInput: undefined;
+				bindArgsParsedInputs: InferArray<BAS>;
+			}
+	: never;
+
+/**
+ * Infer the result type of a safe action.
+ */
+export type InferSafeActionFnResult<T extends Function> = T extends
+	| SafeActionFn<
+			infer ServerError,
+			infer S extends Schema | undefined,
+			infer BAS extends readonly Schema[],
+			infer CVE,
+			infer CBAVE,
+			infer Data
+	  >
+	| SafeStateActionFn<
+			infer ServerError,
+			infer S extends Schema | undefined,
+			infer BAS extends readonly Schema[],
+			infer CVE,
+			infer CBAVE,
+			infer Data
+	  >
+	? SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>
+	: never;
+
+/**
+ * Infer the context type of a safe action client.
+ */
+export type InferSafeActionClientCtx<T> =
+	T extends SafeActionClient<any, any, any, any, infer Ctx extends object, any, any, any, any, any> ? Ctx : never;
+
+/**
+ * Infer the metadata type of a safe action client.
+ */
+export type InferSafeActionClientMetadata<T> =
+	T extends SafeActionClient<any, any, any, infer MD, any, any, any, any, any, any> ? MD : never;
+
+/**
+ * Infer the next context type returned by a middleware function.
+ */
+export type InferMiddlewareFnNextCtx<T> =
+	T extends MiddlewareFn<any, any, any, infer NextCtx extends object> ? NextCtx : never;
+
+/**
+ * Infer the server error type from a safe action client or a middleware function or a safe action function.
+ */
+export type InferServerError<T> = T extends
+	| SafeActionClient<infer ServerError, any, any, any, any, any, any, any, any, any>
+	| MiddlewareFn<infer ServerError, any, any, any>
+	| SafeActionFn<infer ServerError, any, any, any, any, any>
+	| SafeStateActionFn<infer ServerError, any, any, any, any, any>
+	? ServerError
+	: never;

--- a/packages/next-safe-action/src/stateful-hooks.ts
+++ b/packages/next-safe-action/src/stateful-hooks.ts
@@ -5,7 +5,7 @@ import {} from "react/experimental";
 import type {} from "zod";
 import type { InferIn, Schema } from "./adapters/types";
 import { getActionShorthandStatusObject, getActionStatus, useActionCallbacks, useExecuteOnMount } from "./hooks-utils";
-import type { HookBaseUtils, HookCallbacks, HookSafeStateActionFn, UseStateActionReturn } from "./hooks.types";
+import type { HookBaseUtils, HookCallbacks, HookSafeStateActionFn, UseStateActionHookReturn } from "./hooks.types";
 /**
  * Use the stateful action from a Client Component via hook. Used for actions defined with [`stateAction`](https://next-safe-action.dev/docs/safe-action-client/instance-methods#action--stateaction).
  * @param safeActionFn The action function
@@ -27,7 +27,7 @@ export const useStateAction = <
 		permalink?: string;
 	} & HookBaseUtils<S> &
 		HookCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
-): UseStateActionReturn<ServerError, S, BAS, CVE, CBAVE, Data> => {
+): UseStateActionHookReturn<ServerError, S, BAS, CVE, CBAVE, Data> => {
 	const [result, dispatcher, isExecuting] = React.useActionState(
 		safeActionFn,
 		utils?.initResult ?? {},

--- a/packages/next-safe-action/src/stateful-hooks.ts
+++ b/packages/next-safe-action/src/stateful-hooks.ts
@@ -5,7 +5,7 @@ import {} from "react/experimental";
 import type {} from "zod";
 import type { InferIn, Schema } from "./adapters/types";
 import { getActionShorthandStatusObject, getActionStatus, useActionCallbacks, useExecuteOnMount } from "./hooks-utils";
-import type { HookBaseUtils, HookCallbacks, HookSafeStateActionFn } from "./hooks.types";
+import type { HookBaseUtils, HookCallbacks, HookSafeStateActionFn, UseStateActionReturn } from "./hooks.types";
 /**
  * Use the stateful action from a Client Component via hook. Used for actions defined with [`stateAction`](https://next-safe-action.dev/docs/safe-action-client/instance-methods#action--stateaction).
  * @param safeActionFn The action function
@@ -27,7 +27,7 @@ export const useStateAction = <
 		permalink?: string;
 	} & HookBaseUtils<S> &
 		HookCallbacks<ServerError, S, BAS, CVE, CBAVE, Data>
-) => {
+): UseStateActionReturn<ServerError, S, BAS, CVE, CBAVE, Data> => {
 	const [result, dispatcher, isExecuting] = React.useActionState(
 		safeActionFn,
 		utils?.initResult ?? {},
@@ -75,7 +75,7 @@ export const useStateAction = <
 
 	return {
 		execute,
-		input: clientInput,
+		input: clientInput as S extends Schema ? InferIn<S> : undefined,
 		result,
 		status,
 		...getActionShorthandStatusObject({ status, isTransitioning }),

--- a/website/docs/types/index.md
+++ b/website/docs/types/index.md
@@ -360,7 +360,7 @@ export type InferSafeActionFnResult<T extends Function> = T extends
 
 ### `InferMiddlewareFnNextCtx`
 
-Infer the next context type returned by a middleware function.
+Infer the next context type returned by a middleware function using the `next` function.
 
 ```typescript
 export type InferMiddlewareFnNextCtx<T> =

--- a/website/docs/types/infer-types.md
+++ b/website/docs/types/infer-types.md
@@ -1,0 +1,244 @@
+---
+sidebar_position: 1
+description: Learn how to infer types with next-safe-action.
+---
+
+# Infer types
+
+next-safe-action, since version 7.6.4, exports utility types for type inference. Here's a guide on how to use them.
+
+Suppose we have declared this safe action client:
+
+```typescript title="src/lib/safe-action.ts"
+import { z } from "zod";
+import { createSafeActionClient, experimental_createMiddleware } from "next-safe-action";
+import { getSessionData } from "@/services/auth"
+
+// Here we declare a standalone auth middleware.
+export const authMiddleware = experimental_createMiddleware<{
+  ctx: { sessionToken: string };
+  metadata: { actionName: string };
+}>().define(async ({ ctx, next }) => {
+  const { sessionId, userId } = await getSessionData(ctx.sessionToken);
+
+  return next({
+    ctx: {
+      sessionId,
+      userId,
+    },
+  });
+});
+
+// Here we declare the safe action client.
+export const actionClient = createSafeActionClient({
+  defineMetadataSchema: () => {
+    return z.object({
+      actionName: z.string(),
+    });
+  },
+  handleReturnedServerError: (e) => {
+    return {
+      errorMessage: e.message,
+    };
+  },
+})
+  .use(async ({ next }) => {
+    return next({
+      ctx: {
+        sessionToken: "someToken",
+      },
+    });
+  })
+  .use(authMiddleware);
+```
+
+And then this action function:
+
+```typescript title="src/app/test-action.ts"
+"use server";
+
+import { z } from "zod";
+import { actionClient } from "@/lib/safe-action";
+
+const testActionSchema = z.object({
+  username: z.string(),
+});
+
+const testActionBindArgsSchemas: [email: z.ZodString, age: z.ZodNumber] = [z.string(), z.number()];
+
+export const testAction = actionClient
+  .use(authMiddleware)
+  .schema(testActionSchema)
+  .bindArgsSchemas(testActionBindArgsSchemas)
+  .action(async () => {
+    return {
+      successful: true,
+    };
+  });
+```
+
+We'll use these exported functions in the following examples.
+
+## `/`
+
+The library exports several utility types from the root path that help you infer types of a safe action client, a middleware function or a safe action function.
+
+Here's the list of utility types exported from `next-safe-action` path:
+- `InferSafeActionFnInput`: infer input types of a safe action function
+- `InferSafeActionFnResult`: infer result type of a safe action function
+- `InferMiddlewareFnNextCtx`: infer the type of context returned by a middleware function using the `next` function
+- `InferCtx`: infer the type of context of a safe action client, or the context passed to a middleware function 
+- `InferMetadata`: infer the type of metadata of a safe action client or middleware function
+- `InferServerError`: infer the type of the `serverError` of a safe action function, middleware function or safe action function
+
+### Example
+
+```typescript
+import type {
+  InferCtx,
+  InferMetadata,
+  InferMiddlewareFnNextCtx,
+  InferSafeActionFnInput,
+  InferSafeActionFnResult,
+  InferServerError,
+} from "next-safe-action";
+import type { actionClient, authMiddleware } from "@/lib/safe-action";
+import type { testAction } from "@/app/test-action";
+
+// Use `InferSafeActionFnInput` to infer the input types of a safe action function.
+type inferredTestActionInput = InferSafeActionFnInput<typeof testAction>;
+/*
+{
+  clientInput: {
+    username: string;
+  };
+  bindArgsClientInputs: [email: string, age: number];
+  parsedInput: {
+    username: string;
+  };
+  bindArgsParsedInputs: [email: string, age: number];
+}
+*/
+
+// Use `InferSafeActionFnResult` to infer the result type of a safe action function.
+type inferredTestActionResult = InferSafeActionFnResult<typeof testAction>;
+/*
+{
+  data?: {
+    successful: boolean;
+  } | undefined;
+  serverError?: string | undefined;
+  validationErrors?: {
+    _errors?: string[];
+    username?: {
+      _errors?: string[];
+    } | undefined;
+  } | undefined;
+  bindArgsValidationErrors?: [email: { _errors?: string[] }, age: { _errors?: string[] }] | undefined;
+}
+*/
+
+// Use `InferMiddlewareFnNextCtx` to infer the type of the context returned by a middleware function using
+// the `next` function.
+type inferredAuthMiddlewareNextCtx = InferMiddlewareFnNextCtx<typeof authMiddleware>;
+/*
+{
+  sessionId: string;
+  userId: string;
+}
+*/
+
+// Use `InferCtx` to infer the type of the context of a safe action client, or the context passed to a
+// middleware function. Here's an example with a safe action client:
+type inferredSafeActionClientCtx = InferCtx<typeof actionClient>;
+/*
+{
+  sessionToken: string;
+} & {
+  sessionId: string;
+  userId: string;
+}
+*/
+
+// Use `InferMetadata` to infer the type of the metadata of a safe action client or middleware function.
+// Here's an example with a middleware function:
+type inferredMiddlewareMetadata = InferMetadata<typeof authMiddleware>;
+/*
+{
+  actionName: string;
+}
+*/
+
+// Use `InferServerError` to infer the type of the `serverError` of a safe action client, middleware function,
+// or safe action function. Here's an example with a safe action:
+type inferredServerError = InferServerError<typeof testAction>;
+/*
+{
+  errorMessage: string;
+}
+*/
+```
+
+## `/hooks`
+
+The library also exports three types from the `/hooks` path that help you infer types when using `useAction`, `useOptimisticAction` and `useStateAction` hooks.
+
+Here's a list of utility types exported from `next-safe-action/hooks`:
+
+- `InferUseActionHookReturn`: infers the return type of the `useAction` hook - only works with actions defined using the [`action`](/docs/safe-action-client/instance-methods#action--stateaction) method
+- `InferUseOptimisticActionHookReturn`: infers the return type of the `useOptimisticAction` hook - only works with stateless actions defined using the [`action`](/docs/safe-action-client/instance-methods#action--stateaction) method
+- `InferUseStateActionHookReturn`: infers the return type of the `useStateAction` hook - only works with stateful actions defined using the [`stateAction`](/docs/safe-action-client/instance-methods#action--stateaction) method
+
+### Example
+
+```typescript
+import type { testAction } from "@/app/test-action";
+
+// Use `InferUseActionHookReturn` to infer the return type of the `useAction` hook with a provided
+// safe action function.
+type inferredTestActionHookReturn = InferUseActionHookReturn<typeof testAction>;
+/*
+{
+  execute: (input: { username: string }) => void;
+  executeAsync: (input: { username: string }) => Promise<SafeActionResult>;
+  input: { username: string };
+  result: SafeActionResult;
+  reset: () => void;
+  status: HookActionStatus;
+} & HookShorthandStatus
+*/
+
+// Use `InferUseActionHookReturn` to infer the return type of the `useOptimisticAction` hook with a provided
+// safe action function. You can pass the server state as the second generic parameter, which defaults
+// to `any`.
+type inferredTestActionOptimisticHookReturn = InferUseOptimisticActionHookReturn<
+  typeof testAction,
+  { myServerState: { foo: string } }
+>;
+/*
+{
+  execute: (input: { username: string }) => void;
+  executeAsync: (input: { username: string }) => Promise<SafeActionResult>;
+  input: { username: string };
+  result: SafeActionResult;
+  reset: () => void;
+  status: HookActionStatus;
+  optimisticState: { myServerState: { foo: string } };
+} & HookShorthandStatus
+*/
+
+// Use `InferUseStateActionHookReturn` to infer the return type of the `useStateAction` hook with a
+// provided stateful safe action. In this case, by providing the type of `testAction` as the
+// generic parameter will, the resulting type will be `never`, because `testAction` is not defined
+// using `stateAction()` method. Supposing that we change the definition of the function to be stateful,
+// the resulting type will be:
+type inferredTestActionStateHookReturn = InferUseStateActionHookReturn<typeof testAction>;
+/*
+{
+  execute: (input: { username: string }) => void;
+  input: { username: string };
+  result: SafeActionResult;
+  status: HookActionStatus;
+} & HookShorthandStatus
+*/
+```


### PR DESCRIPTION
Code in this PR adds and exports infer utility types for safe action client, middleware functions, safe actions and hooks.

## Related issue(s) or discussion(s)

re #233