### PR TITLE
feat: support output data validation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/TheEdoRan/next-safe-action/assets/1337629/664eb3ee-92f3-4d4a-
 - ✅ End-to-end type safety
 - ✅ Form Actions support
 - ✅ Powerful middleware system
-- ✅ Input validation using multiple validation libraries
+- ✅ Input/output validation using multiple validation libraries
 - ✅ Advanced server error handling
 - ✅ Optimistic updates
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"cz-conventional-changelog": "^3.3.0",
 		"husky": "^9.0.11",
 		"is-ci": "^3.0.1",
-		"turbo": "^2.0.14"
+		"turbo": "^2.1.0"
 	},
 	"packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/packages/next-safe-action/README.md
+++ b/packages/next-safe-action/README.md
@@ -17,7 +17,7 @@ https://github.com/TheEdoRan/next-safe-action/assets/1337629/664eb3ee-92f3-4d4a-
 - ✅ End-to-end type safety
 - ✅ Form Actions support
 - ✅ Powerful middleware system
-- ✅ Input validation using multiple validation libraries
+- ✅ Input/output validation using multiple validation libraries
 - ✅ Advanced server error handling
 - ✅ Optimistic updates
 

--- a/packages/next-safe-action/src/__tests__/happy-path.test.ts
+++ b/packages/next-safe-action/src/__tests__/happy-path.test.ts
@@ -38,14 +38,17 @@ test("action with no input schema and return data gives back an object with corr
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
-test("action with input schema and return data gives back an object with correct `data`", async () => {
+test("action with input, output schema and return data gives back an object with correct `data`", async () => {
 	const userId = "ed6f5b84-6bca-4d01-9a51-c3d0c49a7996";
 
-	const action = ac.schema(z.object({ userId: z.string().uuid() })).action(async ({ parsedInput }) => {
-		return {
-			userId: parsedInput.userId,
-		};
-	});
+	const action = ac
+		.schema(z.object({ userId: z.string().uuid() }))
+		.outputSchema(z.object({ userId: z.string() }))
+		.action(async ({ parsedInput }) => {
+			return {
+				userId: parsedInput.userId,
+			};
+		});
 
 	const actualResult = await action({ userId });
 
@@ -80,13 +83,14 @@ test("action with input schema passed via async function and return data gives b
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
-test("action with input schema extended via async function and return data gives back an object with correct `data`", async () => {
+test("action with input schema extended via async function, ouput schema and return data gives back an object with correct `data`", async () => {
 	const userId = "ed6f5b84-6bca-4d01-9a51-c3d0c49a7996";
 	const password = "password";
 
 	const action = ac
 		.schema(z.object({ password: z.string() }))
 		.schema(async (prevSchema) => prevSchema.extend({ userId: z.string().uuid() }))
+		.outputSchema(z.object({ userId: z.string(), password: z.string() }))
 		.action(async ({ parsedInput }) => {
 			return {
 				userId: parsedInput.userId,
@@ -106,12 +110,13 @@ test("action with input schema extended via async function and return data gives
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
-test("action with no input schema, bind args input schemas and return data gives back an object with correct `data`", async () => {
+test("action with no input schema, with bind args input schemas, output schema and return data gives back an object with correct `data`", async () => {
 	const username = "johndoe";
 	const age = 30;
 
 	const action = ac
 		.bindArgsSchemas<[username: z.ZodString, age: z.ZodNumber]>([z.string(), z.number()])
+		.outputSchema(z.object({ username: z.string(), age: z.number() }))
 		.action(async ({ bindArgsParsedInputs: [username, age] }) => {
 			return {
 				username,
@@ -131,7 +136,7 @@ test("action with no input schema, bind args input schemas and return data gives
 	assert.deepStrictEqual(actualResult, expectedResult);
 });
 
-test("action with input schema, bind args input schemas and return data gives back an object with correct `data`", async () => {
+test("action with input schema, bind args input schemas, output schema and return data gives back an object with correct `data`", async () => {
 	const userId = "ed6f5b84-6bca-4d01-9a51-c3d0c49a7996";
 	const username = "johndoe";
 	const age = 30;
@@ -139,6 +144,7 @@ test("action with input schema, bind args input schemas and return data gives ba
 	const action = ac
 		.schema(z.object({ userId: z.string().uuid() }))
 		.bindArgsSchemas<[username: z.ZodString, age: z.ZodNumber]>([z.string(), z.number()])
+		.outputSchema(z.object({ userId: z.string(), username: z.string(), age: z.number() }))
 		.action(async ({ parsedInput, bindArgsParsedInputs: [username, age] }) => {
 			return {
 				userId: parsedInput.userId,

--- a/packages/next-safe-action/src/__tests__/validation-errors.test.ts
+++ b/packages/next-safe-action/src/__tests__/validation-errors.test.ts
@@ -12,7 +12,7 @@ import {
 	returnValidationErrors,
 } from "..";
 import { zodAdapter } from "../adapters/zod";
-import { ActionOutputDataError } from "../utils";
+import { ActionOutputDataValidationError } from "../validation-errors";
 
 // Default client tests.
 
@@ -195,7 +195,7 @@ test("action with invalid output data throws an error of the correct type", asyn
 	try {
 		await action();
 	} catch (e) {
-		if (e instanceof ActionOutputDataError) {
+		if (e instanceof ActionOutputDataValidationError) {
 			actualResult.serverError =
 				(e.validationErrors as ValidationErrors<typeof outputSchema>).result?._errors?.[0] ?? "";
 		}

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -14,9 +14,15 @@ import type {
 	ServerCodeFn,
 	StateServerCodeFn,
 } from "./index.types";
-import { ActionMetadataError, ActionOutputDataError, DEFAULT_SERVER_ERROR_MESSAGE, isError } from "./utils";
+import { DEFAULT_SERVER_ERROR_MESSAGE, isError } from "./utils";
 import type { MaybePromise } from "./utils.types";
-import { ActionServerValidationError, ActionValidationError, buildValidationErrors } from "./validation-errors";
+import {
+	ActionMetadataValidationError,
+	ActionOutputDataValidationError,
+	ActionServerValidationError,
+	ActionValidationError,
+	buildValidationErrors,
+} from "./validation-errors";
 import type {
 	BindArgsValidationErrors,
 	HandleBindArgsValidationErrorsShapeFn,
@@ -112,7 +118,7 @@ export function actionBuilder<
 									const parsedMd = await args.validationAdapter.validate(args.metadataSchema, args.metadata);
 
 									if (!parsedMd.success) {
-										throw new ActionMetadataError<MetadataSchema>(buildValidationErrors(parsedMd.issues));
+										throw new ActionMetadataValidationError<MetadataSchema>(buildValidationErrors(parsedMd.issues));
 									}
 								}
 							}
@@ -217,7 +223,7 @@ export function actionBuilder<
 									const parsedData = await args.validationAdapter.validate(args.outputSchema, data);
 
 									if (!parsedData.success) {
-										throw new ActionOutputDataError<OS>(buildValidationErrors(parsedData.issues));
+										throw new ActionOutputDataValidationError<OS>(buildValidationErrors(parsedData.issues));
 									}
 								}
 

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -14,7 +14,7 @@ import type {
 	ServerCodeFn,
 	StateServerCodeFn,
 } from "./index.types";
-import { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE, isError } from "./utils";
+import { ActionMetadataError, ActionOutputDataError, DEFAULT_SERVER_ERROR_MESSAGE, isError } from "./utils";
 import type { MaybePromise } from "./utils.types";
 import { ActionServerValidationError, ActionValidationError, buildValidationErrors } from "./validation-errors";
 import type {
@@ -27,18 +27,20 @@ import type {
 export function actionBuilder<
 	ServerError,
 	MetadataSchema extends Schema | undefined = undefined,
-	MD = MetadataSchema extends Schema ? Infer<Schema> : undefined,
+	MD = MetadataSchema extends Schema ? Infer<Schema> : undefined, // metadata type (inferred from metadata schema)
 	Ctx extends object = {},
-	SF extends (() => Promise<Schema>) | undefined = undefined, // schema function
-	S extends Schema | undefined = SF extends Function ? Awaited<ReturnType<SF>> : undefined,
+	ISF extends (() => Promise<Schema>) | undefined = undefined, // input schema function
+	IS extends Schema | undefined = ISF extends Function ? Awaited<ReturnType<ISF>> : undefined, // input schema
+	OS extends Schema | undefined = undefined, // output schema
 	const BAS extends readonly Schema[] = [],
 	CVE = undefined,
 	CBAVE = undefined,
 >(args: {
-	schemaFn?: SF;
+	inputSchemaFn?: ISF;
 	bindArgsSchemas?: BAS;
+	outputSchema?: OS;
 	validationAdapter: ValidationAdapter;
-	handleValidationErrorsShape: HandleValidationErrorsShapeFn<S, CVE>;
+	handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, CVE>;
 	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	metadataSchema: MetadataSchema;
 	metadata: MD;
@@ -53,29 +55,29 @@ export function actionBuilder<
 	const bindArgsSchemas = (args.bindArgsSchemas ?? []) as BAS;
 
 	function buildAction({ withState }: { withState: false }): {
-		action: <Data>(
-			serverCodeFn: ServerCodeFn<MD, Ctx, S, BAS, Data>,
-			utils?: SafeActionUtils<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
-		) => SafeActionFn<ServerError, S, BAS, CVE, CBAVE, Data>;
+		action: <Data extends OS extends Schema ? Infer<OS> : any>(
+			serverCodeFn: ServerCodeFn<MD, Ctx, IS, BAS, Data>,
+			utils?: SafeActionUtils<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>
+		) => SafeActionFn<ServerError, IS, BAS, CVE, CBAVE, Data>;
 	};
 	function buildAction({ withState }: { withState: true }): {
-		action: <Data>(
-			serverCodeFn: StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>,
-			utils?: SafeActionUtils<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
-		) => SafeStateActionFn<ServerError, S, BAS, CVE, CBAVE, Data>;
+		action: <Data extends OS extends Schema ? Infer<OS> : any>(
+			serverCodeFn: StateServerCodeFn<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>,
+			utils?: SafeActionUtils<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>
+		) => SafeStateActionFn<ServerError, IS, BAS, CVE, CBAVE, Data>;
 	};
 	function buildAction({ withState }: { withState: boolean }) {
 		return {
-			action: <Data>(
+			action: <Data extends OS extends Schema ? Infer<OS> : any>(
 				serverCodeFn:
-					| ServerCodeFn<MD, Ctx, S, BAS, Data>
-					| StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>,
-				utils?: SafeActionUtils<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>
+					| ServerCodeFn<MD, Ctx, IS, BAS, Data>
+					| StateServerCodeFn<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>,
+				utils?: SafeActionUtils<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>
 			) => {
 				return async (...clientInputs: unknown[]) => {
 					let currentCtx: object = {};
 					const middlewareResult: MiddlewareResult<ServerError, object> = { success: false };
-					type PrevResult = SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data> | undefined;
+					type PrevResult = SafeActionResult<ServerError, IS, BAS, CVE, CBAVE, Data> | undefined;
 					let prevResult: PrevResult | undefined = undefined;
 					const parsedInputDatas: any[] = [];
 					let frameworkError: Error | null = null;
@@ -107,10 +109,10 @@ export function actionBuilder<
 							if (idx === 0) {
 								if (args.metadataSchema) {
 									// Validate metadata input.
-									if (!(await args.validationAdapter.validate(args.metadataSchema, args.metadata)).success) {
-										throw new ActionMetadataError(
-											"Invalid metadata input. Please be sure to pass metadata via `metadata` method before defining the action."
-										);
+									const parsedMd = await args.validationAdapter.validate(args.metadataSchema, args.metadata);
+
+									if (!parsedMd.success) {
+										throw new ActionMetadataError<MetadataSchema>(buildValidationErrors(parsedMd.issues));
 									}
 								}
 							}
@@ -124,7 +126,6 @@ export function actionBuilder<
 									metadata: args.metadata,
 									next: async (nextOpts) => {
 										currentCtx = deepmerge(currentCtx, nextOpts?.ctx ?? {});
-										// currentCtx = { ...cloneDeep(currentCtx), ...(nextOpts?.ctx ?? {}) };
 										await executeMiddlewareStack(idx + 1);
 										return middlewareResult;
 									},
@@ -137,7 +138,7 @@ export function actionBuilder<
 										// Last client input in the array, main argument (no bind arg).
 										if (i === clientInputs.length - 1) {
 											// If schema is undefined, set parsed data to undefined.
-											if (typeof args.schemaFn === "undefined") {
+											if (typeof args.inputSchemaFn === "undefined") {
 												return {
 													success: true,
 													data: undefined,
@@ -145,7 +146,7 @@ export function actionBuilder<
 											}
 
 											// Otherwise, parse input with the schema.
-											return args.validationAdapter.validate(await args.schemaFn(), input);
+											return args.validationAdapter.validate(await args.inputSchemaFn(), input);
 										}
 
 										// Otherwise, we're processing bind args client inputs.
@@ -172,7 +173,7 @@ export function actionBuilder<
 											hasBindValidationErrors = true;
 										} else {
 											// Otherwise, we're processing the non-bind argument (the last one) in the array.
-											const validationErrors = buildValidationErrors<S>(parsedInput.issues);
+											const validationErrors = buildValidationErrors<IS>(parsedInput.issues);
 
 											middlewareResult.validationErrors = await Promise.resolve(
 												args.handleValidationErrorsShape(validationErrors)
@@ -193,11 +194,11 @@ export function actionBuilder<
 								}
 
 								// @ts-expect-error
-								const scfArgs: Parameters<StateServerCodeFn<ServerError, MD, Ctx, S, BAS, CVE, CBAVE, Data>> = [];
+								const scfArgs: Parameters<StateServerCodeFn<ServerError, MD, Ctx, IS, BAS, CVE, CBAVE, Data>> = [];
 
 								// Server code function always has this object as the first argument.
 								scfArgs[0] = {
-									parsedInput: parsedInputDatas.at(-1) as S extends Schema ? Infer<S> : undefined,
+									parsedInput: parsedInputDatas.at(-1) as IS extends Schema ? Infer<IS> : undefined,
 									bindArgsParsedInputs: parsedInputDatas.slice(0, -1) as InferArray<BAS>,
 									ctx: currentCtx as Ctx,
 									metadata: args.metadata,
@@ -210,6 +211,15 @@ export function actionBuilder<
 								}
 
 								const data = await serverCodeFn(...scfArgs);
+
+								// If a `outputSchema` is passed, validate the action return value.
+								if (typeof args.outputSchema !== "undefined") {
+									const parsedData = await args.validationAdapter.validate(args.outputSchema, data);
+
+									if (!parsedData.success) {
+										throw new ActionOutputDataError<OS>(buildValidationErrors(parsedData.issues));
+									}
+								}
 
 								middlewareResult.success = true;
 								middlewareResult.data = data;
@@ -227,7 +237,7 @@ export function actionBuilder<
 
 							// If error is `ActionServerValidationError`, return `validationErrors` as if schema validation would fail.
 							if (e instanceof ActionServerValidationError) {
-								const ve = e.validationErrors as ValidationErrors<S>;
+								const ve = e.validationErrors as ValidationErrors<IS>;
 								middlewareResult.validationErrors = await Promise.resolve(args.handleValidationErrorsShape(ve));
 							} else {
 								// If error is not an instance of Error, wrap it in an Error object with
@@ -269,9 +279,9 @@ export function actionBuilder<
 								data: undefined,
 								metadata: args.metadata,
 								ctx: currentCtx as Ctx,
-								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
+								clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
-								parsedInput: parsedInputDatas.at(-1) as S extends Schema ? Infer<S> : undefined,
+								parsedInput: parsedInputDatas.at(-1) as IS extends Schema ? Infer<IS> : undefined,
 								bindArgsParsedInputs: parsedInputDatas.slice(0, -1) as InferArray<BAS>,
 								hasRedirected: isRedirectError(frameworkError),
 								hasNotFound: isNotFoundError(frameworkError),
@@ -282,7 +292,7 @@ export function actionBuilder<
 							utils?.onSettled?.({
 								metadata: args.metadata,
 								ctx: currentCtx as Ctx,
-								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
+								clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 								result: {},
 								hasRedirected: isRedirectError(frameworkError),
@@ -295,7 +305,7 @@ export function actionBuilder<
 						throw frameworkError;
 					}
 
-					const actionResult: SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data> = {};
+					const actionResult: SafeActionResult<ServerError, IS, BAS, CVE, CBAVE, Data> = {};
 
 					if (typeof middlewareResult.validationErrors !== "undefined") {
 						// Throw validation errors if either `throwValidationErrors` property at the action or instance level is `true`.
@@ -333,9 +343,9 @@ export function actionBuilder<
 								metadata: args.metadata,
 								ctx: currentCtx as Ctx,
 								data: actionResult.data as Data,
-								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
+								clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
-								parsedInput: parsedInputDatas.at(-1) as S extends Schema ? Infer<S> : undefined,
+								parsedInput: parsedInputDatas.at(-1) as IS extends Schema ? Infer<IS> : undefined,
 								bindArgsParsedInputs: parsedInputDatas.slice(0, -1) as InferArray<BAS>,
 								hasRedirected: false,
 								hasNotFound: false,
@@ -346,7 +356,7 @@ export function actionBuilder<
 							utils?.onError?.({
 								metadata: args.metadata,
 								ctx: currentCtx as Ctx,
-								clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
+								clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
 								bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 								error: actionResult,
 							})
@@ -358,7 +368,7 @@ export function actionBuilder<
 						utils?.onSettled?.({
 							metadata: args.metadata,
 							ctx: currentCtx as Ctx,
-							clientInput: clientInputs.at(-1) as S extends Schema ? InferIn<S> : undefined,
+							clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
 							bindArgsClientInputs: (bindArgsSchemas.length ? clientInputs.slice(0, -1) : []) as InferInArray<BAS>,
 							result: actionResult,
 							hasRedirected: false,

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -11,8 +11,10 @@ import {
 } from "./validation-errors";
 
 export { createMiddleware } from "./middleware";
-export { ActionOutputDataError as ActionDataError, ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
+export { DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
 export {
+	ActionMetadataValidationError,
+	ActionOutputDataValidationError,
 	ActionValidationError,
 	flattenBindArgsValidationErrors,
 	flattenValidationErrors,

--- a/packages/next-safe-action/src/index.ts
+++ b/packages/next-safe-action/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./validation-errors";
 
 export { createMiddleware } from "./middleware";
-export { ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
+export { ActionOutputDataError as ActionDataError, ActionMetadataError, DEFAULT_SERVER_ERROR_MESSAGE } from "./utils";
 export {
 	ActionValidationError,
 	flattenBindArgsValidationErrors,
@@ -59,8 +59,9 @@ export const createSafeActionClient = <
 		middlewareFns: [async ({ next }) => next({ ctx: {} })],
 		handleServerErrorLog,
 		handleReturnedServerError,
-		schemaFn: undefined,
+		inputSchemaFn: undefined,
 		bindArgsSchemas: [],
+		outputSchema: undefined,
 		validationAdapter: createOpts?.validationAdapter ?? zodAdapter(), // use zod adapter by default
 		ctxType: {},
 		metadataSchema: (createOpts?.defineMetadataSchema?.() ?? undefined) as MetadataSchema,

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,3 +1,6 @@
+import type { Schema } from "./adapters/types";
+import type { ValidationErrors } from "./validation-errors.types";
+
 export const DEFAULT_SERVER_ERROR_MESSAGE = "Something went wrong while executing the operation.";
 
 export const isError = (error: unknown): error is Error => error instanceof Error;
@@ -6,9 +9,28 @@ export const isError = (error: unknown): error is Error => error instanceof Erro
  * This error is thrown when an action's metadata input is invalid, i.e. when there's a mismatch between the
  * type of the metadata schema returned from `defineMetadataSchema` and the actual input.
  */
-export class ActionMetadataError extends Error {
-	constructor(message: string) {
-		super(message);
+export class ActionMetadataError<MDS extends Schema | undefined> extends Error {
+	public validationErrors: ValidationErrors<MDS>;
+
+	constructor(validationErrors: ValidationErrors<MDS>) {
+		super("Invalid metadata input. Please be sure to pass metadata via `metadata` method before defining the action.");
 		this.name = "ActionMetadataError";
+		this.validationErrors = validationErrors;
+	}
+}
+
+/**
+ * This error is thrown when an action's data (output) is invalid, i.e. when there's a mismatch between the
+ * type of the data schema passed to `dataSchema` method and the actual return of the action.
+ */
+export class ActionOutputDataError<DS extends Schema | undefined> extends Error {
+	public validationErrors: ValidationErrors<DS>;
+
+	constructor(validationErrors: ValidationErrors<DS>) {
+		super(
+			"Invalid action data (output). Please be sure to return data following the shape of the schema passed to `dataSchema` method."
+		);
+		this.name = "ActionOutputDataError";
+		this.validationErrors = validationErrors;
 	}
 }

--- a/packages/next-safe-action/src/utils.ts
+++ b/packages/next-safe-action/src/utils.ts
@@ -1,36 +1,3 @@
-import type { Schema } from "./adapters/types";
-import type { ValidationErrors } from "./validation-errors.types";
-
 export const DEFAULT_SERVER_ERROR_MESSAGE = "Something went wrong while executing the operation.";
 
 export const isError = (error: unknown): error is Error => error instanceof Error;
-
-/**
- * This error is thrown when an action's metadata input is invalid, i.e. when there's a mismatch between the
- * type of the metadata schema returned from `defineMetadataSchema` and the actual input.
- */
-export class ActionMetadataError<MDS extends Schema | undefined> extends Error {
-	public validationErrors: ValidationErrors<MDS>;
-
-	constructor(validationErrors: ValidationErrors<MDS>) {
-		super("Invalid metadata input. Please be sure to pass metadata via `metadata` method before defining the action.");
-		this.name = "ActionMetadataError";
-		this.validationErrors = validationErrors;
-	}
-}
-
-/**
- * This error is thrown when an action's data (output) is invalid, i.e. when there's a mismatch between the
- * type of the data schema passed to `dataSchema` method and the actual return of the action.
- */
-export class ActionOutputDataError<DS extends Schema | undefined> extends Error {
-	public validationErrors: ValidationErrors<DS>;
-
-	constructor(validationErrors: ValidationErrors<DS>) {
-		super(
-			"Invalid action data (output). Please be sure to return data following the shape of the schema passed to `dataSchema` method."
-		);
-		this.name = "ActionOutputDataError";
-		this.validationErrors = validationErrors;
-	}
-}

--- a/packages/next-safe-action/src/validation-errors.ts
+++ b/packages/next-safe-action/src/validation-errors.ts
@@ -144,3 +144,33 @@ export function flattenBindArgsValidationErrors<BAVE extends readonly Validation
 ) {
 	return bindArgsValidationErrors.map((ve) => flattenValidationErrors(ve)) as FlattenedBindArgsValidationErrors<BAVE>;
 }
+
+/**
+ * This error is thrown when an action metadata is invalid, i.e. when there's a mismatch between the
+ * type of the metadata schema returned from `defineMetadataSchema` and the actual data passed.
+ */
+export class ActionMetadataValidationError<MDS extends Schema | undefined> extends Error {
+	public validationErrors: ValidationErrors<MDS>;
+
+	constructor(validationErrors: ValidationErrors<MDS>) {
+		super("Invalid metadata input. Please be sure to pass metadata via `metadata` method before defining the action.");
+		this.name = "ActionMetadataError";
+		this.validationErrors = validationErrors;
+	}
+}
+
+/**
+ * This error is thrown when an action's data (output) is invalid, i.e. when there's a mismatch between the
+ * type of the data schema passed to `dataSchema` method and the actual return of the action.
+ */
+export class ActionOutputDataValidationError<DS extends Schema | undefined> extends Error {
+	public validationErrors: ValidationErrors<DS>;
+
+	constructor(validationErrors: ValidationErrors<DS>) {
+		super(
+			"Invalid action data (output). Please be sure to return data following the shape of the schema passed to `dataSchema` method."
+		);
+		this.name = "ActionOutputDataError";
+		this.validationErrors = validationErrors;
+	}
+}

--- a/packages/next-safe-action/src/validation-errors.ts
+++ b/packages/next-safe-action/src/validation-errors.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 
-import type { Schema } from "./adapters/types";
+import type { Schema, ValidationIssue } from "./adapters/types";
 import type {
 	FlattenedBindArgsValidationErrors,
 	FlattenedValidationErrors,
 	ValidationErrors,
-	ValidationIssue,
 } from "./validation-errors.types";
 
 // This function is used internally to build the validation errors object from a list of validation issues.

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -1,11 +1,6 @@
 import type { Infer, Schema } from "./adapters/types";
 import type { Prettify } from "./utils.types";
 
-export type ValidationIssue = {
-	message: string;
-	path?: Array<string | number | symbol>;
-};
-
 // Object with an optional list of validation errors.
 type VEList = Prettify<{ _errors?: string[] }>;
 

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -10,7 +10,7 @@ type SchemaErrors<S> = {
 } & {};
 
 /**
- * Type of the returned object when input validation fails.
+ * Type of the returned object when validation fails.
  */
 export type ValidationErrors<S extends Schema | undefined> = S extends Schema
 	? Infer<S> extends object

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       turbo:
-        specifier: ^2.0.14
-        version: 2.0.14
+        specifier: ^2.1.0
+        version: 2.1.0
 
   apps/playground:
     dependencies:
@@ -3718,38 +3718,38 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.0.14:
-    resolution: {integrity: sha512-kwfDmjNwlNfvtrvT29+ZBg5n1Wvxl891bFHchMJyzMoR0HOE9N1NSNdSZb9wG3e7sYNIu4uDkNk+VBEqJW0HzQ==}
+  turbo-darwin-64@2.1.0:
+    resolution: {integrity: sha512-gHwpDk2gyB7qZ57gUUwDIS/IkglqEjjVtPZCTxmCRg28Tiwjui0azsLVKrnHP9UZHllozwbi28x8HXLXLEFF1w==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.14:
-    resolution: {integrity: sha512-m3LXYEshCx3wc4ZClM6gb01KYpFmtjQ9IBF3A7ofjb6ahux3xlYZJZ3uFCLAGHuvGLuJ3htfiPbwlDPTdknqqw==}
+  turbo-darwin-arm64@2.1.0:
+    resolution: {integrity: sha512-GLaqGetNC6eS4eqXgsheLOHic/OcnGCGDi5boVf+TFZTXYH6YE15L4ugZha4xHXCr1KouCLILHh+f8EHEmWylg==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.14:
-    resolution: {integrity: sha512-7vBzCPdoTtR92SNn2JMgj1FlMmyonGmpMaQdgAB1OVYtuQ6NVGoh7/lODfaILqXjpvmFSVbpBIDrKOT6EvcprQ==}
+  turbo-linux-64@2.1.0:
+    resolution: {integrity: sha512-VzBOsj7JyGoZtiNZZ6brjnY7UehRnClluw7pwznuLPzClkqOOPMd2jOcgkWxnP/xW4NBmOoFANXXrtvKBD4f2w==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.14:
-    resolution: {integrity: sha512-jwH+c0bfjpBf26K/tdEFatmnYyXwGROjbr6bZmNcL8R+IkGAc/cglL+OToqJnQZTgZvH7uDGbeSyUo7IsHyjuA==}
+  turbo-linux-arm64@2.1.0:
+    resolution: {integrity: sha512-St7svJnOO5g4F6R7Z32e10I/0M3e6qpNjEYybXwPNul9NSfnUXeky4WoKaALwqNhyJ7nYemoFpZ1d+i8hFQTHg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.14:
-    resolution: {integrity: sha512-w9/XwkHSzvLjmioo6cl3S1yRfI6swxsV1j1eJwtl66JM4/pn0H2rBa855R0n7hZnmI6H5ywLt/nLt6Ae8RTDmw==}
+  turbo-windows-64@2.1.0:
+    resolution: {integrity: sha512-iSobNud2MrJ1SZ1upVPlErT8xexsr0MQtKapdfq6z0M0rBnrDGEq5bUCSScWyGu+O4+glB4br9xkTAkGFqaxqQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.14:
-    resolution: {integrity: sha512-XaQlyYk+Rf4xS5XWCo8XCMIpssgGGy8blzLfolN6YBp4baElIWMlkLZHDbGyiFmCbNf9I9gJI64XGRG+LVyyjA==}
+  turbo-windows-arm64@2.1.0:
+    resolution: {integrity: sha512-d61jN4rjE5PnUfF66GKrKoj8S8Ql4FGXzFFzZz4kjsHpZZzCTtqlzPZBmd1byzGYhDPTorTqG3G1USohbdyohA==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.14:
-    resolution: {integrity: sha512-00JjdCMD/cpsjP0Izkjcm8Oaor5yUCfDwODtaLb+WyblyadkaDEisGhy3Dbd5az9n+5iLSPiUgf+WjPbns6MRg==}
+  turbo@2.1.0:
+    resolution: {integrity: sha512-A969/LO/sPHKlapIarY2VVzqQ5JnnW2/1kksZlnMEpsRD6gwOELvVL+ozfMiO7av9RILt3UeN02L17efr6HUCA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7658,32 +7658,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.0.14:
+  turbo-darwin-64@2.1.0:
     optional: true
 
-  turbo-darwin-arm64@2.0.14:
+  turbo-darwin-arm64@2.1.0:
     optional: true
 
-  turbo-linux-64@2.0.14:
+  turbo-linux-64@2.1.0:
     optional: true
 
-  turbo-linux-arm64@2.0.14:
+  turbo-linux-arm64@2.1.0:
     optional: true
 
-  turbo-windows-64@2.0.14:
+  turbo-windows-64@2.1.0:
     optional: true
 
-  turbo-windows-arm64@2.0.14:
+  turbo-windows-arm64@2.1.0:
     optional: true
 
-  turbo@2.0.14:
+  turbo@2.1.0:
     optionalDependencies:
-      turbo-darwin-64: 2.0.14
-      turbo-darwin-arm64: 2.0.14
-      turbo-linux-64: 2.0.14
-      turbo-linux-arm64: 2.0.14
-      turbo-windows-64: 2.0.14
-      turbo-windows-arm64: 2.0.14
+      turbo-darwin-64: 2.1.0
+      turbo-darwin-arm64: 2.1.0
+      turbo-linux-64: 2.1.0
+      turbo-linux-arm64: 2.1.0
+      turbo-windows-64: 2.1.0
+      turbo-windows-arm64: 2.1.0
 
   type-check@0.4.0:
     dependencies:

--- a/website/docs/safe-action-client/instance-methods.md
+++ b/website/docs/safe-action-client/instance-methods.md
@@ -28,7 +28,7 @@ metadata(data: Metadata) => new SafeActionClient()
 ## `schema`
 
 ```typescript
-schema(schema: S, utils?: { handleValidationErrorsShape?: HandleValidationErrorsShapeFn } }) => new SafeActionClient()
+schema(inputSchema: S, utils?: { handleValidationErrorsShape?: HandleValidationErrorsShapeFn } }) => new SafeActionClient()
 ```
 
 `schema` accepts an input schema of type `Schema` or a function that returns a promise of type `Schema` and an optional `utils` object that accepts a [`handleValidationErrorsShape`](/docs/recipes/customize-validation-errors-format) function. The schema is used to define the arguments that the safe action will receive, the optional [`handleValidationErrorsShape`](/docs/recipes/customize-validation-errors-format) function is used to return a custom format for validation errors. If you don't pass an input schema, `parsedInput` and validation errors will be typed `undefined`, and `clientInput` will be typed `void`. It returns a new instance of the safe action client.
@@ -40,6 +40,14 @@ bindArgsSchemas(bindArgsSchemas: BAS, bindArgsUtils?: { handleBindArgsValidation
 ```
 
 `bindArgsSchemas` accepts an array of bind input schemas of type `Schema[]` and an optional `bindArgsUtils` object that accepts a `handleBindArgsValidationErrorsShape` function. The schema is used to define the bind arguments that the safe action will receive, the optional `handleBindArgsValidationErrorsShape` function is used to [return a custom format for bind arguments validation errors](/docs/recipes/customize-validation-errors-format). It returns a new instance of the safe action client.
+
+## `outputSchema`
+
+```typescript
+outputSchema(outputSchema: S) => new SafeActionClient()
+```
+
+`outputSchema` accepts a schema of type `Schema`. That schema is used to define what the safe action will return. If you don't pass an output schema when you're defining an action, the return type will be inferred instead. If validation fails, an `ActionOutputDataValidationError` is internally thrown. You can catch it inside [`handleReturnedServerError`](/docs/safe-action-client/initialization-options#handlereturnedservererror)/[`handleServerErrorLog`](/docs/safe-action-client/initialization-options#handleservererrorlog) and access the `validationErrors` property to get the validation errors. It returns a new instance of the safe action client.
 
 ## `action` / `stateAction`
 

--- a/website/docs/types/index.md
+++ b/website/docs/types/index.md
@@ -246,7 +246,7 @@ export type SafeActionUtils<
 
 ### `ValidationErrors`
 
-Type of the returned object when input validation fails.
+Type of the returned object when validation fails.
 
 ```typescript
 export type ValidationErrors<S extends Schema | undefined> = S extends Schema

--- a/website/src/components/landing/features.tsx
+++ b/website/src/components/landing/features.tsx
@@ -23,8 +23,8 @@ const features: { title: string; description: string }[] = [
 			"Manage authorization, log and halt execution, and much more with a composable middleware system.",
 	},
 	{
-		title: "Input validation using multiple validation libraries",
-		description: `Input passed from the client to the server is validated using Zod, Valibot or Yup.`,
+		title: "Input/output validation using multiple validation libraries",
+		description: `Input and output are validated using your favorite library.`,
 	},
 	{
 		title: "Advanced server error handling",

--- a/website/src/components/landing/hero.tsx
+++ b/website/src/components/landing/hero.tsx
@@ -18,7 +18,8 @@ export function Hero() {
 									</h1>
 									<h2 className="text-zinc-700 dark:text-zinc-300 font-medium text-base sm:text-lg md:text-xl max-w-xl">
 										next-safe-action handles your Next.js app mutations type
-										safety, input validation, server errors and even more!
+										safety, input/output validation, server errors and even
+										more!
 									</h2>
 								</div>
 								<div className="flex justify-center items-center">


### PR DESCRIPTION
This PR adds the `outputSchema` method to allow for optional validation of the action's return value.

## Related issue(s) or discussion(s)

re #245