### PR TITLE
refactor: pass utils to validation errors shape customizer functions

### DIFF
--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -47,7 +47,7 @@ export function actionBuilder<
 	outputSchema?: OS;
 	validationAdapter: ValidationAdapter;
 	handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
-	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
+	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<IS, BAS, MD, Ctx, CBAVE>;
 	metadataSchema: MetadataSchema;
 	metadata: MD;
 	handleServerError: NonNullable<SafeActionClientOpts<ServerError, MetadataSchema, any>["handleServerError"]>;
@@ -195,7 +195,17 @@ export function actionBuilder<
 								// If there are bind args validation errors, format them and store them in the middleware result.
 								if (hasBindValidationErrors) {
 									middlewareResult.bindArgsValidationErrors = await Promise.resolve(
-										args.handleBindArgsValidationErrorsShape(bindArgsValidationErrors as BindArgsValidationErrors<BAS>)
+										args.handleBindArgsValidationErrorsShape(
+											bindArgsValidationErrors as BindArgsValidationErrors<BAS>,
+											{
+												clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
+												bindArgsClientInputs: (bindArgsSchemas.length
+													? clientInputs.slice(0, -1)
+													: []) as InferInArray<BAS>,
+												ctx: currentCtx as Ctx,
+												metadata: args.metadata as MetadataSchema extends Schema ? Infer<MetadataSchema> : undefined,
+											}
+										)
 									);
 								}
 

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -46,7 +46,7 @@ export function actionBuilder<
 	bindArgsSchemas?: BAS;
 	outputSchema?: OS;
 	validationAdapter: ValidationAdapter;
-	handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, CVE>;
+	handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
 	handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	metadataSchema: MetadataSchema;
 	metadata: MD;
@@ -179,7 +179,14 @@ export function actionBuilder<
 											const validationErrors = buildValidationErrors<IS>(parsedInput.issues);
 
 											middlewareResult.validationErrors = await Promise.resolve(
-												args.handleValidationErrorsShape(validationErrors)
+												args.handleValidationErrorsShape(validationErrors, {
+													clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
+													bindArgsClientInputs: (bindArgsSchemas.length
+														? clientInputs.slice(0, -1)
+														: []) as InferInArray<BAS>,
+													ctx: currentCtx as Ctx,
+													metadata: args.metadata as MetadataSchema extends Schema ? Infer<MetadataSchema> : undefined,
+												})
 											);
 										}
 									}
@@ -241,7 +248,16 @@ export function actionBuilder<
 							// If error is `ActionServerValidationError`, return `validationErrors` as if schema validation would fail.
 							if (e instanceof ActionServerValidationError) {
 								const ve = e.validationErrors as ValidationErrors<IS>;
-								middlewareResult.validationErrors = await Promise.resolve(args.handleValidationErrorsShape(ve));
+								middlewareResult.validationErrors = await Promise.resolve(
+									args.handleValidationErrorsShape(ve, {
+										clientInput: clientInputs.at(-1) as IS extends Schema ? InferIn<IS> : undefined,
+										bindArgsClientInputs: (bindArgsSchemas.length
+											? clientInputs.slice(0, -1)
+											: []) as InferInArray<BAS>,
+										ctx: currentCtx as Ctx,
+										metadata: args.metadata as MetadataSchema extends Schema ? Infer<MetadataSchema> : undefined,
+									})
+								);
 							} else {
 								// If error is not an instance of Error, wrap it in an Error object with
 								// the default message.

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -43,7 +43,7 @@ export class SafeActionClient<
 	readonly #bindArgsSchemas: BAS;
 	readonly #validationAdapter: ValidationAdapter;
 	readonly #handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
-	readonly #handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
+	readonly #handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<IS, BAS, MD, Ctx, CBAVE>;
 	readonly #defaultValidationErrorsShape: ODVES;
 	readonly #throwValidationErrors: boolean;
 
@@ -57,7 +57,7 @@ export class SafeActionClient<
 			bindArgsSchemas: BAS;
 			validationAdapter: ValidationAdapter;
 			handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
-			handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
+			handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<IS, BAS, MD, Ctx, CBAVE>;
 			ctxType: Ctx;
 		} & Required<
 			Pick<
@@ -164,7 +164,8 @@ export class SafeActionClient<
 			validationAdapter: this.#validationAdapter,
 			handleValidationErrorsShape: (utils?.handleValidationErrorsShape ??
 				this.#handleValidationErrorsShape) as HandleValidationErrorsShapeFn<AIS, BAS, MD, Ctx, OCVE>,
-			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
+			handleBindArgsValidationErrorsShape: this
+				.#handleBindArgsValidationErrorsShape as HandleBindArgsValidationErrorsShapeFn<AIS, BAS, MD, Ctx, CBAVE>,
 			ctxType: {} as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 			throwValidationErrors: this.#throwValidationErrors,
@@ -185,7 +186,7 @@ export class SafeActionClient<
 			: BindArgsValidationErrors<OBAS>,
 	>(
 		bindArgsSchemas: OBAS,
-		utils?: { handleBindArgsValidationErrorsShape?: HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE> }
+		utils?: { handleBindArgsValidationErrorsShape?: HandleBindArgsValidationErrorsShapeFn<IS, OBAS, MD, Ctx, OCBAVE> }
 	) {
 		return new SafeActionClient({
 			middlewareFns: this.#middlewareFns,
@@ -204,7 +205,7 @@ export class SafeActionClient<
 				CVE
 			>,
 			handleBindArgsValidationErrorsShape: (utils?.handleBindArgsValidationErrorsShape ??
-				this.#handleBindArgsValidationErrorsShape) as HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE>,
+				this.#handleBindArgsValidationErrorsShape) as HandleBindArgsValidationErrorsShapeFn<IS, OBAS, MD, Ctx, OCBAVE>,
 			ctxType: {} as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
 			throwValidationErrors: this.#throwValidationErrors,

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -42,7 +42,7 @@ export class SafeActionClient<
 	readonly #ctxType: Ctx;
 	readonly #bindArgsSchemas: BAS;
 	readonly #validationAdapter: ValidationAdapter;
-	readonly #handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, CVE>;
+	readonly #handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
 	readonly #handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 	readonly #defaultValidationErrorsShape: ODVES;
 	readonly #throwValidationErrors: boolean;
@@ -56,7 +56,7 @@ export class SafeActionClient<
 			outputSchema: OS;
 			bindArgsSchemas: BAS;
 			validationAdapter: ValidationAdapter;
-			handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, CVE>;
+			handleValidationErrorsShape: HandleValidationErrorsShapeFn<IS, BAS, MD, Ctx, CVE>;
 			handleBindArgsValidationErrorsShape: HandleBindArgsValidationErrorsShapeFn<BAS, CBAVE>;
 			ctxType: Ctx;
 		} & Required<
@@ -143,7 +143,7 @@ export class SafeActionClient<
 	>(
 		inputSchema: OIS,
 		utils?: {
-			handleValidationErrorsShape?: HandleValidationErrorsShapeFn<AIS, OCVE>;
+			handleValidationErrorsShape?: HandleValidationErrorsShapeFn<AIS, BAS, MD, Ctx, OCVE>;
 		}
 	) {
 		return new SafeActionClient({
@@ -163,7 +163,7 @@ export class SafeActionClient<
 			outputSchema: this.#outputSchema,
 			validationAdapter: this.#validationAdapter,
 			handleValidationErrorsShape: (utils?.handleValidationErrorsShape ??
-				this.#handleValidationErrorsShape) as HandleValidationErrorsShapeFn<AIS, OCVE>,
+				this.#handleValidationErrorsShape) as HandleValidationErrorsShapeFn<AIS, BAS, MD, Ctx, OCVE>,
 			handleBindArgsValidationErrorsShape: this.#handleBindArgsValidationErrorsShape,
 			ctxType: {} as Ctx,
 			defaultValidationErrorsShape: this.#defaultValidationErrorsShape,
@@ -196,7 +196,13 @@ export class SafeActionClient<
 			bindArgsSchemas,
 			outputSchema: this.#outputSchema,
 			validationAdapter: this.#validationAdapter,
-			handleValidationErrorsShape: this.#handleValidationErrorsShape,
+			handleValidationErrorsShape: this.#handleValidationErrorsShape as unknown as HandleValidationErrorsShapeFn<
+				IS,
+				OBAS,
+				MD,
+				Ctx,
+				CVE
+			>,
 			handleBindArgsValidationErrorsShape: (utils?.handleBindArgsValidationErrorsShape ??
 				this.#handleBindArgsValidationErrorsShape) as HandleBindArgsValidationErrorsShapeFn<OBAS, OCBAVE>,
 			ctxType: {} as Ctx,

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -1,4 +1,4 @@
-import type { Infer, Schema } from "./adapters/types";
+import type { Infer, InferIn, Schema } from "./adapters/types";
 import type { Prettify } from "./utils.types";
 
 // Object with an optional list of validation errors.
@@ -46,8 +46,20 @@ export type FlattenedBindArgsValidationErrors<BAVE extends readonly ValidationEr
 /**
  * Type of the function used to format validation errors.
  */
-export type HandleValidationErrorsShapeFn<S extends Schema | undefined, CVE> = (
-	validationErrors: ValidationErrors<S>
+export type HandleValidationErrorsShapeFn<
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	MD,
+	Ctx extends object,
+	CVE,
+> = (
+	validationErrors: ValidationErrors<S>,
+	utils: {
+		clientInput: S extends Schema ? InferIn<S> : undefined;
+		bindArgsClientInputs: BAS;
+		metadata: MD;
+		ctx: Prettify<Ctx>;
+	}
 ) => CVE;
 
 /**

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -65,6 +65,18 @@ export type HandleValidationErrorsShapeFn<
 /**
  * Type of the function used to format bind arguments validation errors.
  */
-export type HandleBindArgsValidationErrorsShapeFn<BAS extends readonly Schema[], CBAVE> = (
-	bindArgsValidationErrors: BindArgsValidationErrors<BAS>
+export type HandleBindArgsValidationErrorsShapeFn<
+	S extends Schema | undefined,
+	BAS extends readonly Schema[],
+	MD,
+	Ctx extends object,
+	CBAVE,
+> = (
+	bindArgsValidationErrors: BindArgsValidationErrors<BAS>,
+	utils: {
+		clientInput: S extends Schema ? InferIn<S> : undefined;
+		bindArgsClientInputs: BAS;
+		metadata: MD;
+		ctx: Prettify<Ctx>;
+	}
 ) => CBAVE;

--- a/website/docs/define-actions/validation-errors.md
+++ b/website/docs/define-actions/validation-errors.md
@@ -13,7 +13,7 @@ This can be customized both at the safe action client level and at the action le
 - using [`defaultValidationErrorsShape`](/docs/define-actions/create-the-client#defaultvalidationerrorsshape) optional property in `createSafeActionClient`;
 - using `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` optional functions in [`schema`](/docs/define-actions/instance-methods#schema) and [`bindArgsSchemas`](/docs/define-actions/instance-methods#bindargsschemas) methods.
 
-The second way overrides the shape set at the instance level, per action. More information below.
+The second way overrides the shape set at the instance level, per action.
 
 For example, if you want to flatten the validation errors (emulation of Zod's [`flatten`](https://zod.dev/ERROR_HANDLING?id=flattening-errors) method), you can (but not required to) use the `flattenValidationErrors` utility function exported from the library, combining it with `handleValidationErrorsShape` inside `schema` method:
 
@@ -39,18 +39,20 @@ export const loginUser = actionClient
     // Here we use the `flattenValidationErrors` function to customize the returned validation errors
     // object to the client.
     // highlight-next-line
-    handleValidationErrorsShape: (ve) => flattenValidationErrors(ve).fieldErrors,
+    handleValidationErrorsShape: (ve, utils) => flattenValidationErrors(ve).fieldErrors,
   })
   .bindArgsSchemas(bindArgsSchemas, {
     // Here we use the `flattenBindArgsValidatonErrors` function to customize the returned bind args
     // validation errors object array to the client.
     // highlight-next-line
-    handleBindArgsValidationErrors: (ve) => flattenBindArgsValidationErrors(ve),
+    handleBindArgsValidationErrors: (ve, utils) => flattenBindArgsValidationErrors(ve),
   })
   .action(async ({ parsedInput: { username, password } }) => {
     // Your code here...
   });
 ```
+
+The second argument of both `handleValidationErrorsShape` and `handleBindArgsValidationErrors` functions is an `utils` object that contains info about the current action execution (`clientInput`, `bindArgsClientInputs`, `metadata` and `ctx` properties). It's passed to the functions to allow granular and dynamic customization of the validation errors shape.
 
 :::note
 If you chain multiple `schema` methods, as explained in the [Extend previous schema](/docs/define-actions/extend-previous-schemas) page, and want to override the default validation errors shape, you **must** use `handleValidationErrorsShape` inside the last `schema` method, otherwise there would be a type mismatch in the returned action result.


### PR DESCRIPTION
# Proposed changes

Code in this PR adds a second argument to `handleValidationErrorsShape` and `handleBindArgsValidationErrorsShape` functions, called `utils`, which is an object that contains `clientInput`, `bindArgsClientInputs`, `metadata` and `ctx` properties. This addition allows you to set dynamic validation errors based on current action execution data.

## Related issue(s) or discussion(s)

re #256
