### PR TITLE
fix: export `SafeActionClient` type to make it portable (#267)

### DIFF
--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -272,3 +272,12 @@ export type InferServerError<T> = T extends
 	| SafeStateActionFn<infer ServerError, any, any, any, any, any>
 	? ServerError
 	: never;
+
+
+/**
+ * Type of the core safe action client.
+ */
+export {
+	SafeActionClient
+};
+


### PR DESCRIPTION
Includes the `SafeActionClient` into the types export to make the inferred type of `createSafeActionClient` portable in order to avoid the error [TS2742](https://typescript.tv/errors/#ts2742). It enables declaring the action client in a shared package and import it in the other apps or packages.

closes #64