### PR TITLE
fix(packages/next-safe-action/src/validation-errors.types.ts)

### DIFF
--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -1,3 +1,4 @@
+import type { BRAND } from 'zod';
 import type { Infer, InferIn, Schema } from "./adapters/types";
 import type { Prettify } from "./utils.types";
 
@@ -6,7 +7,13 @@ type VEList = Prettify<{ _errors?: string[] }>;
 
 // Creates nested schema validation errors type using recursion.
 type SchemaErrors<S> = {
-	[K in keyof S]?: S[K] extends object | null | undefined ? Prettify<VEList & SchemaErrors<S[K]>> : VEList;
+	[K in keyof S]?: S[K] extends object | null | undefined
+    ? S[K] extends BRAND<infer branded_type>
+      ? branded_type extends object | null | undefined
+        ? Prettify<VEList & SchemaErrors<S[K]>>
+      : VEList
+    : Prettify<VEList & SchemaErrors<S[K]>>
+  : VEList;
 } & {};
 
 /**


### PR DESCRIPTION
# Proposed changes

returnValidationErrors() typechecking fails when a property is a zod-branded-primitive-type, 
`type SchemaErrors<S>` considers a zod-branded-primitive-type as an object instead as a primitive, leading to a typecheck error. 
Fixed `type SchemaErrors<S>` definition to detect branded-primitives and behave correctly

---

- [x] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
