### PR TITLE
support primitive-object-intersection types (branded primitive types)

### DIFF
--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -1,3 +1,4 @@
+import type { BRAND } from 'zod';
 import type { Infer, InferIn, Schema } from "./adapters/types";
 import type { Prettify } from "./utils.types";
 
@@ -6,7 +7,13 @@ type VEList = Prettify<{ _errors?: string[] }>;
 
 // Creates nested schema validation errors type using recursion.
 type SchemaErrors<S> = {
-	[K in keyof S]?: S[K] extends object | null | undefined ? Prettify<VEList & SchemaErrors<S[K]>> : VEList;
+	[K in keyof S]?: S[K] extends object | null | undefined
+    ? S[K] extends BRAND<infer branded_type>
+      ? branded_type extends object | null | undefined
+        ? Prettify<VEList & SchemaErrors<S[K]>>
+      : VEList
+    : Prettify<VEList & SchemaErrors<S[K]>>
+  : VEList;
 } & {};
 
 /**

--- a/packages/next-safe-action/src/validation-errors.types.ts
+++ b/packages/next-safe-action/src/validation-errors.types.ts
@@ -1,4 +1,3 @@
-import type { BRAND } from 'zod';
 import type { Infer, InferIn, Schema } from "./adapters/types";
 import type { Prettify } from "./utils.types";
 
@@ -7,15 +6,10 @@ type VEList = Prettify<{ _errors?: string[] }>;
 
 // Creates nested schema validation errors type using recursion.
 type SchemaErrors<S> = {
-	[K in keyof S]?: S[K] extends object | null | undefined
-    ? S[K] extends BRAND<infer branded_type>
-      ? branded_type extends object | null | undefined
-        ? Prettify<VEList & SchemaErrors<S[K]>>
-      : VEList
-    : Prettify<VEList & SchemaErrors<S[K]>>
-  : VEList;
+  [K in keyof S]?: S[K] extends number | string | boolean | bigint
+    ? VEList
+    : Prettify<VEList & SchemaErrors<S[K]>>;
 } & {};
-
 /**
  * Type of the returned object when validation fails.
  */


### PR DESCRIPTION
`returnValidationErrors()` typechecking fails when a property is a primitive-object-intersection type (typical case of branded type). 

`returnValidationErrors()` refers to `type SchemaErrors<S>` for typings
the purpose of `type SchemaErrors<S>` as is:
```
type SchemaErrors<S> = {
	[K in keyof S]?: S[K] extends object | null | undefined 
	  ? Prettify<VEList & SchemaErrors<S[K]>> 
	  : VEList;
} & {};
```
is to map `S` properties conditionally:
if property `S[K]`  is `object | null | undefined`  maps to `Prettify<VEList & SchemaErrors<S[K]>>` 
else (property `S[K]`  is primitive)  maps to `VEList`

the issue arises when property `S[K]` is a branded primitive type.
Branded primitive types are typically an intersection of a primitive with an object holding the brand 
(e.g. `type email = string & { [k in brand_prop_type]: unique symbol }`)

`type SchemaErrors<S>` mapping condition considers branded-primitive-types as object, mapping them incorrectly, and finally leading to `returnValidationErrors()` type errors

# Proposed changes

the issue is resolved by simply reversing the condition:

```
type SchemaErrors<S> = {
  [K in keyof S]?: S[K] extends number | string | boolean | bigint
    ? VEList
    : Prettify<VEList & SchemaErrors<S[K]>>;
} & {};
```
this way any primitive - even when intersected - is eagerly catched and properly managed, keeping logic unaltered  


## Related issue(s) or discussion(s)

This is an improvement of a previous PR
https://github.com/TheEdoRan/next-safe-action/pull/273

re #

---

- [x] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
