### PR TITLE
refactor(types): less strict callbacks return type

### DIFF
--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -289,7 +289,7 @@ export function actionBuilder<
 					// Execute middleware chain + action function.
 					await executeMiddlewareStack();
 
-					const callbacksToExecute: MaybePromise<void>[] = [];
+					const callbacksToExecute: MaybePromise<unknown>[] = [];
 
 					// If an internal framework error occurred, throw it, so it will be processed by Next.js.
 					if (frameworkError) {

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -27,16 +27,16 @@ export type HookCallbacks<
 	CBAVE,
 	Data,
 > = {
-	onExecute?: (args: { input: S extends Schema ? InferIn<S> : undefined }) => MaybePromise<void>;
-	onSuccess?: (args: { data?: Data; input: S extends Schema ? InferIn<S> : undefined }) => MaybePromise<void>;
+	onExecute?: (args: { input: S extends Schema ? InferIn<S> : undefined }) => MaybePromise<unknown>;
+	onSuccess?: (args: { data?: Data; input: S extends Schema ? InferIn<S> : undefined }) => MaybePromise<unknown>;
 	onError?: (args: {
 		error: Prettify<Omit<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>, "data">>;
 		input: S extends Schema ? InferIn<S> : undefined;
-	}) => MaybePromise<void>;
+	}) => MaybePromise<unknown>;
 	onSettled?: (args: {
 		result: Prettify<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>>;
 		input: S extends Schema ? InferIn<S> : undefined;
-	}) => MaybePromise<void>;
+	}) => MaybePromise<unknown>;
 };
 
 /**

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -175,14 +175,14 @@ export type SafeActionUtils<
 		bindArgsParsedInputs: InferArray<BAS>;
 		hasRedirected: boolean;
 		hasNotFound: boolean;
-	}) => MaybePromise<void>;
+	}) => MaybePromise<unknown>;
 	onError?: (args: {
 		error: Prettify<Omit<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>, "data">>;
 		metadata: MD;
 		ctx?: Prettify<Ctx>;
 		clientInput: S extends Schema ? InferIn<S> : undefined;
 		bindArgsClientInputs: InferInArray<BAS>;
-	}) => MaybePromise<void>;
+	}) => MaybePromise<unknown>;
 	onSettled?: (args: {
 		result: Prettify<SafeActionResult<ServerError, S, BAS, CVE, CBAVE, Data>>;
 		metadata: MD;
@@ -191,7 +191,7 @@ export type SafeActionUtils<
 		bindArgsClientInputs: InferInArray<BAS>;
 		hasRedirected: boolean;
 		hasNotFound: boolean;
-	}) => MaybePromise<void>;
+	}) => MaybePromise<unknown>;
 };
 
 /**


### PR DESCRIPTION

# Proposed changes

allows hook callbacks to call functions that have a return value other than void without wrapping in a closure. E.g. `onSuccess: () => toast.success('...')` where `toast.success` returns the toast id. I understand that the return value of the callback isn't used for anything but this allows for slightly cleaner code imo.

## Related issue(s) or discussion(s)

---

- [x] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
