### PR TITLE
fix: handle framework errors properly in middlewares.

### DIFF
--- a/packages/next-safe-action/src/__tests__/middleware.test.ts
+++ b/packages/next-safe-action/src/__tests__/middleware.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
+import { redirect } from "next/navigation";
 import assert from "node:assert";
 import { test } from "node:test";
 import { z } from "zod";
@@ -12,8 +13,7 @@ import {
 	returnValidationErrors,
 } from "..";
 import { zodAdapter } from "../adapters/zod";
-import { redirect } from "next/navigation";
-import { isFrameworkError } from "../next/errors";
+import { FrameworkErrorHandler } from "../next/errors";
 
 const ac = createSafeActionClient({
 	validationAdapter: zodAdapter(),
@@ -317,7 +317,7 @@ test("framework error result from middleware is correct", async () => {
 
 	const inputs = [{ age: 30 }, { username: "johndoe" }] as const;
 	await action(...inputs).catch((e) => {
-		if (!isFrameworkError(e)) {
+		if (!FrameworkErrorHandler.isFrameworkError(e)) {
 			throw e;
 		}
 	});
@@ -353,7 +353,7 @@ test("framework error is thrown within middleware", async () => {
 	await assert.rejects(
 		async () => await action(),
 		(e) => {
-			return isFrameworkError(e);
+			return FrameworkErrorHandler.isFrameworkError(e);
 		},
 		"A framework error to be thrown"
 	);

--- a/packages/next-safe-action/src/__tests__/middleware.test.ts
+++ b/packages/next-safe-action/src/__tests__/middleware.test.ts
@@ -341,6 +341,24 @@ test("framework error result from middleware is correct", async () => {
 	assert.deepStrictEqual(middlewareResult, expectedResult);
 });
 
+test("framework error is thrown within middleware", async () => {
+	const action = ac
+		.use(async () => {
+			redirect("/newPath");
+		})
+		.action(async () => {
+			return null;
+		});
+
+	await assert.rejects(
+		async () => await action(),
+		(e) => {
+			return isFrameworkError(e);
+		},
+		"A framework error to be thrown"
+	);
+});
+
 // Flattened validation errors shape.
 
 const flac = createSafeActionClient({

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -130,7 +130,7 @@ export function actionBuilder<
 										await executeMiddlewareStack(idx + 1);
 										return middlewareResult;
 									},
-								}).catch(frameworkErrorHandler.handleError);
+								}).catch((e) => frameworkErrorHandler.handleError(e));
 								// Action function.
 							} else {
 								// Validate the client inputs in parallel.
@@ -230,7 +230,7 @@ export function actionBuilder<
 									scfArgs[1] = { prevResult: structuredClone(prevResult!) };
 								}
 
-								const data = await serverCodeFn(...scfArgs).catch(frameworkErrorHandler.handleError);
+								const data = await serverCodeFn(...scfArgs).catch((e) => frameworkErrorHandler.handleError(e));
 
 								// If a `outputSchema` is passed, validate the action return value.
 								if (typeof args.outputSchema !== "undefined" && !frameworkErrorHandler.error) {

--- a/packages/next-safe-action/src/next/errors/index.ts
+++ b/packages/next-safe-action/src/next/errors/index.ts
@@ -12,7 +12,7 @@ export class FrameworkErrorHandler {
 		return isNextRouterError(error) || isBailoutToCSRError(error) || isDynamicUsageError(error) || isPostpone(error);
 	}
 
-	handleError = (e: unknown) => {
+	handleError(e: unknown) {
 		// next/navigation functions work by throwing an error that will be
 		// processed internally by Next.js.
 		if (FrameworkErrorHandler.isFrameworkError(e)) {
@@ -21,7 +21,7 @@ export class FrameworkErrorHandler {
 		}
 
 		throw e;
-	};
+	}
 
 	get error() {
 		return this.#frameworkError;

--- a/packages/next-safe-action/src/next/errors/index.ts
+++ b/packages/next-safe-action/src/next/errors/index.ts
@@ -1,28 +1,45 @@
 import { isBailoutToCSRError } from "./bailout-to-csr";
 import { isDynamicUsageError } from "./dynamic-usage";
-import {
-	getAccessFallbackHTTPStatus,
-	isHTTPAccessFallbackError,
-	type HTTPAccessFallbackError,
-} from "./http-access-fallback";
+import { getAccessFallbackHTTPStatus, isHTTPAccessFallbackError } from "./http-access-fallback";
 import { isPostpone } from "./postpone";
+import { isRedirectError } from "./redirect";
 import { isNextRouterError } from "./router";
 
-export function isNotFoundError(error: unknown): error is HTTPAccessFallbackError {
-	return isHTTPAccessFallbackError(error) && getAccessFallbackHTTPStatus(error) === 404;
-}
+export class FrameworkErrorHandler {
+	#frameworkError: Error | undefined;
 
-export function isForbiddenError(error: unknown): error is HTTPAccessFallbackError {
-	return isHTTPAccessFallbackError(error) && getAccessFallbackHTTPStatus(error) === 403;
-}
+	static isFrameworkError(error: unknown): error is Error {
+		return isNextRouterError(error) || isBailoutToCSRError(error) || isDynamicUsageError(error) || isPostpone(error);
+	}
 
-export function isUnauthorizedError(error: unknown): error is HTTPAccessFallbackError {
-	return isHTTPAccessFallbackError(error) && getAccessFallbackHTTPStatus(error) === 401;
-}
+	handleError = (e: unknown) => {
+		// next/navigation functions work by throwing an error that will be
+		// processed internally by Next.js.
+		if (FrameworkErrorHandler.isFrameworkError(e)) {
+			this.#frameworkError = e;
+			return;
+		}
 
-// Next.js error handling
-export function isFrameworkError(error: unknown): error is Error {
-	return isNextRouterError(error) || isBailoutToCSRError(error) || isDynamicUsageError(error) || isPostpone(error);
-}
+		throw e;
+	};
 
-export { isRedirectError } from "./redirect";
+	get error() {
+		return this.#frameworkError;
+	}
+
+	get isRedirectError() {
+		return isRedirectError(this.#frameworkError);
+	}
+
+	get isNotFoundError() {
+		return isHTTPAccessFallbackError(this.#frameworkError) && getAccessFallbackHTTPStatus(this.#frameworkError) === 404;
+	}
+
+	get isForbiddenError() {
+		return isHTTPAccessFallbackError(this.#frameworkError) && getAccessFallbackHTTPStatus(this.#frameworkError) === 403;
+	}
+
+	get isUnauthorizedError() {
+		return isHTTPAccessFallbackError(this.#frameworkError) && getAccessFallbackHTTPStatus(this.#frameworkError) === 401;
+	}
+}


### PR DESCRIPTION
Although #303 has been resolved, I had also been investigating the same issue. During my analysis, I noticed that framework errors were not being caught in the most appropriate location, resulting in failure to retrieve all expected values from `next()` when `success=true`.

To illustrate the problem clearly, I added a related test in commit efe6a9641318c2616e2c67f697b4c107b0d598d2. This test demonstrates that the existing code does not pass. I then applied a fix in commit ec108ae337754a207ec44133bab72a98bb7b5b63, which resolves the issue.