### PR TITLE
refactor: make safe action result always defined

### DIFF
--- a/apps/playground/src/app/(examples)/direct/page.tsx
+++ b/apps/playground/src/app/(examples)/direct/page.tsx
@@ -8,7 +8,7 @@ import { ResultBox } from "../../_components/result-box";
 import { loginUser } from "./login-action";
 
 export default function DirectExamplePage() {
-	const [result, setResult] = useState<any>(undefined);
+	const [result, setResult] = useState<any>({});
 
 	return (
 		<main className="w-96 max-w-full px-4">

--- a/apps/playground/src/app/(examples)/hook/page.tsx
+++ b/apps/playground/src/app/(examples)/hook/page.tsx
@@ -22,17 +22,20 @@ export default function Hook() {
 		hasSucceeded,
 		hasErrored,
 	} = useAction(deleteUser, {
-		onSuccess({ data, input }) {
-			console.log("HELLO FROM ONSUCCESS", data, input);
+		onSuccess(args) {
+			console.log("HELLO FROM ONSUCCESS", args);
 		},
-		onError({ error, input }) {
-			console.log("OH NO FROM ONERROR", error, input);
+		onError(args) {
+			console.log("OH NO FROM ONERROR", args);
 		},
-		onSettled({ result, input }) {
-			console.log("HELLO FROM ONSETTLED", result, input);
+		onNavigation(args) {
+			console.log("OH NO FROM ONNAVIGATION", args);
 		},
-		onExecute({ input }) {
-			console.log("HELLO FROM ONEXECUTE", input);
+		onSettled(args) {
+			console.log("HELLO FROM ONSETTLED", args);
+		},
+		onExecute(args) {
+			console.log("HELLO FROM ONEXECUTE", args);
 		},
 	});
 

--- a/apps/playground/src/app/(examples)/navigation/page.tsx
+++ b/apps/playground/src/app/(examples)/navigation/page.tsx
@@ -39,6 +39,7 @@ export default function Navigation() {
 	});
 
 	console.dir({
+		result,
 		status,
 		isIdle,
 		isExecuting,

--- a/apps/playground/src/app/(examples)/optimistic-hook/addtodo-form.tsx
+++ b/apps/playground/src/app/(examples)/optimistic-hook/addtodo-form.tsx
@@ -17,17 +17,20 @@ const AddTodoForm = ({ todos }: Props) => {
 		updateFn: (state, newTodo) => ({
 			todos: [...state.todos, newTodo],
 		}),
-		onSuccess({ data, input }) {
-			console.log("HELLO FROM ONSUCCESS", data, input);
+		onSuccess(args) {
+			console.log("HELLO FROM ONSUCCESS", args);
 		},
-		onError({ error, input }) {
-			console.log("OH NO FROM ONERROR", error, input);
+		onError(args) {
+			console.log("OH NO FROM ONERROR", args);
 		},
-		onSettled({ result, input }) {
-			console.log("HELLO FROM ONSETTLED", result, input);
+		onNavigation(args) {
+			console.log("OH NO FROM ONNAVIGATION", args);
 		},
-		onExecute({ input }) {
-			console.log("HELLO FROM ONEXECUTE", input);
+		onSettled(args) {
+			console.log("HELLO FROM ONSETTLED", args);
+		},
+		onExecute(args) {
+			console.log("HELLO FROM ONEXECUTE", args);
 		},
 	});
 

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -78,8 +78,8 @@ export function actionBuilder<
 				return async (...clientInputs: unknown[]) => {
 					let currentCtx: object = {};
 					const middlewareResult: MiddlewareResult<ServerError, object> = { success: false };
-					type PrevResult = SafeActionResult<ServerError, IS, CVE, Data> | undefined;
-					let prevResult: PrevResult | undefined = undefined;
+					type PrevResult = SafeActionResult<ServerError, IS, CVE, Data>;
+					let prevResult: PrevResult = {};
 					const parsedInputDatas: any[] = [];
 					const frameworkErrorHandler = new FrameworkErrorHandler();
 
@@ -216,7 +216,7 @@ export function actionBuilder<
 								// If this action is stateful, server code function also has a `prevResult` property inside the second
 								// argument object.
 								if (withState) {
-									scfArgs[1] = { prevResult: structuredClone(prevResult!) };
+									scfArgs[1] = { prevResult: structuredClone(prevResult) };
 								}
 
 								const data = await serverCodeFn(...scfArgs).catch((e) => frameworkErrorHandler.handleError(e));

--- a/packages/next-safe-action/src/hooks.types.ts
+++ b/packages/next-safe-action/src/hooks.types.ts
@@ -28,7 +28,7 @@ export type HookCallbacks<ServerError, S extends StandardSchemaV1 | undefined, C
  */
 export type HookSafeActionFn<ServerError, S extends StandardSchemaV1 | undefined, CVE, Data> = (
 	input: InferInputOrDefault<S, undefined>
-) => Promise<SafeActionResult<ServerError, S, CVE, Data> | undefined>;
+) => Promise<SafeActionResult<ServerError, S, CVE, Data>>;
 
 /**
  * Type of the stateful safe action function passed to hooks. Same as `SafeStateActionFn` except it accepts
@@ -62,9 +62,7 @@ export type HookShorthandStatus = {
  */
 export type UseActionHookReturn<ServerError, S extends StandardSchemaV1 | undefined, CVE, Data> = {
 	execute: (input: InferInputOrDefault<S, void>) => void;
-	executeAsync: (
-		input: InferInputOrDefault<S, void>
-	) => Promise<SafeActionResult<ServerError, S, CVE, Data> | undefined>;
+	executeAsync: (input: InferInputOrDefault<S, void>) => Promise<SafeActionResult<ServerError, S, CVE, Data>>;
 	input: InferInputOrDefault<S, undefined>;
 	result: Prettify<SafeActionResult<ServerError, S, CVE, Data>>;
 	reset: () => void;

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -66,7 +66,7 @@ export type SafeActionFn<
 	Data,
 > = (
 	...clientInputs: [...bindArgsInputs: InferInputArray<BAS>, input: InferInputOrDefault<S, void>]
-) => Promise<SafeActionResult<ServerError, S, CVE, Data> | undefined>;
+) => Promise<SafeActionResult<ServerError, S, CVE, Data>>;
 
 /**
  * Type of the stateful function called from components with type safe input data.


### PR DESCRIPTION
Code in this PR brings back the always defined safe action result, so users can destructure the result object, and access its optional properties directly. This is because `next/navigation` functions don't trigger an `undefined` result anymore, so everything works as expected now.