### PR TITLE
refactor: rename `schema` method to `inputSchema`, and deprecate it

### DIFF
--- a/apps/playground/src/app/(examples)/async-schema/login-action.ts
+++ b/apps/playground/src/app/(examples)/async-schema/login-action.ts
@@ -13,7 +13,7 @@ async function getSchema() {
 
 export const loginUser = action
 	.metadata({ actionName: "loginUser" })
-	.schema(getSchema, {
+	.inputSchema(getSchema, {
 		// Here we use the `flattenValidationErrors` function to customize the returned validation errors
 		// object to the client.
 		handleValidationErrorsShape: async (ve) => flattenValidationErrors(ve).fieldErrors,

--- a/apps/playground/src/app/(examples)/bind-arguments/onboard-action.ts
+++ b/apps/playground/src/app/(examples)/bind-arguments/onboard-action.ts
@@ -11,7 +11,7 @@ const bindArgsSchemas: [userId: z.ZodString, age: z.ZodNumber] = [z.string().uui
 
 export const onboardUser = action
 	.metadata({ actionName: "onboardUser" })
-	.schema(schema)
+	.inputSchema(schema)
 	.bindArgsSchemas(bindArgsSchemas)
 	.action(async ({ parsedInput: { username }, bindArgsParsedInputs: [userId, age] }) => {
 		await new Promise((res) => setTimeout(res, 1000));

--- a/apps/playground/src/app/(examples)/direct/login-action.ts
+++ b/apps/playground/src/app/(examples)/direct/login-action.ts
@@ -11,7 +11,7 @@ const schema = z.object({
 
 export const loginUser = action
 	.metadata({ actionName: "loginUser" })
-	.schema(schema, {
+	.inputSchema(schema, {
 		// Here we use the `flattenValidationErrors` function to customize the returned validation errors
 		// object to the client.
 		handleValidationErrorsShape: async (ve) => flattenValidationErrors(ve).fieldErrors,

--- a/apps/playground/src/app/(examples)/empty-response/empty-action.ts
+++ b/apps/playground/src/app/(examples)/empty-response/empty-action.ts
@@ -9,7 +9,7 @@ const schema = z.object({
 
 export const emptyAction = action
 	.metadata({ actionName: "emptyAction" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async () => {
 		await new Promise((res) => setTimeout(res, 500));
 	});

--- a/apps/playground/src/app/(examples)/file-upload/file-upload-action.ts
+++ b/apps/playground/src/app/(examples)/file-upload/file-upload-action.ts
@@ -9,7 +9,7 @@ const schema = zfd.formData({
 
 export const fileUploadAction = action
 	.metadata({ actionName: "fileUploadAction" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async ({ parsedInput }) => {
 		await new Promise((res) => setTimeout(res, 1000));
 

--- a/apps/playground/src/app/(examples)/hook/deleteuser-action.ts
+++ b/apps/playground/src/app/(examples)/hook/deleteuser-action.ts
@@ -9,7 +9,7 @@ const schema = z.object({
 
 export const deleteUser = action
 	.metadata({ actionName: "deleteUser" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async ({ parsedInput: { userId } }) => {
 		await new Promise((res) => setTimeout(res, 1000));
 

--- a/apps/playground/src/app/(examples)/navigation/navigation-action.ts
+++ b/apps/playground/src/app/(examples)/navigation/navigation-action.ts
@@ -10,7 +10,7 @@ const schema = z.object({
 
 export const testNavigate = action
 	.metadata({ actionName: "testNavigate" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(
 		async ({ parsedInput: { kind } }) => {
 			await new Promise((res) => setTimeout(res, 1000));

--- a/apps/playground/src/app/(examples)/nested-schema/shop-action.ts
+++ b/apps/playground/src/app/(examples)/nested-schema/shop-action.ts
@@ -70,7 +70,7 @@ const schema = z
 
 export const buyProduct = action
 	.metadata({ actionName: "buyProduct" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async () => {
 		return {
 			success: true,

--- a/apps/playground/src/app/(examples)/optimistic-hook/addtodo-action.ts
+++ b/apps/playground/src/app/(examples)/optimistic-hook/addtodo-action.ts
@@ -17,7 +17,7 @@ export const getTodos = async () => todos;
 
 export const addTodo = action
 	.metadata({ actionName: "" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async ({ parsedInput }) => {
 		await new Promise((res) => setTimeout(res, 500));
 

--- a/apps/playground/src/app/(examples)/react-hook-form/buyproduct-action.ts
+++ b/apps/playground/src/app/(examples)/react-hook-form/buyproduct-action.ts
@@ -6,7 +6,7 @@ import { schema } from "./validation";
 
 export const buyProduct = action
 	.metadata({ actionName: "buyProduct" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async ({ parsedInput: { productId } }) => {
 		return {
 			productId,

--- a/apps/playground/src/app/(examples)/stateful-form/stateful-form-action.ts
+++ b/apps/playground/src/app/(examples)/stateful-form/stateful-form-action.ts
@@ -14,7 +14,7 @@ const schema = zfd.formData({
 // though, you can omit the type here, since it will be inferred just like with `action` method.
 export const statefulFormAction = action
 	.metadata({ actionName: "statefulFormAction" })
-	.schema(schema)
+	.inputSchema(schema)
 	.stateAction<{
 		prevName?: string;
 		newName: string;

--- a/apps/playground/src/app/(examples)/stateless-form/stateless-form-action.ts
+++ b/apps/playground/src/app/(examples)/stateless-form/stateless-form-action.ts
@@ -10,7 +10,7 @@ const schema = zfd.formData({
 
 export const statelessFormAction = action
 	.metadata({ actionName: "statelessFormAction" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(async ({ parsedInput }) => {
 		await new Promise((res) => setTimeout(res, 1000));
 

--- a/apps/playground/src/app/(examples)/with-context/edituser-action.ts
+++ b/apps/playground/src/app/(examples)/with-context/edituser-action.ts
@@ -10,7 +10,7 @@ const schema = z.object({
 
 export const editUser = authAction
 	.metadata({ actionName: "editUser" })
-	.schema(schema)
+	.inputSchema(schema)
 	.action(
 		// Here you have access to `userId`, and `sessionId which comes from middleware functions
 		// defined before.

--- a/packages/next-safe-action/src/safe-action-client.ts
+++ b/packages/next-safe-action/src/safe-action-client.ts
@@ -121,7 +121,7 @@ export class SafeActionClient<
 	 *
 	 * {@link https://next-safe-action.dev/docs/define-actions/create-the-client#inputschema See docs for more information}
 	 */
-	schema<
+	inputSchema<
 		OIS extends StandardSchemaV1 | ((prevSchema: IS) => Promise<StandardSchemaV1>), // override input schema
 		AIS extends StandardSchemaV1 = OIS extends (prevSchema: IS) => Promise<StandardSchemaV1>
 			? Awaited<ReturnType<OIS>>
@@ -155,6 +155,11 @@ export class SafeActionClient<
 			throwValidationErrors: this.#throwValidationErrors,
 		});
 	}
+
+	/**
+	 * @deprecated Alias for `inputSchema` method. Use that instead.
+	 */
+	schema = this.inputSchema;
 
 	/**
 	 * Define the bind args input validation schema for the action.


### PR DESCRIPTION
The code in this PR renames the `schema` instance method to `inputSchema`.
Since introducing output validation with the `outputSchema` method, I have considered renaming `schema` to `inputSchema` to make its purpose clearer.

Note that the `schema` method will remain as an alias for `inputSchema`, but will be removed in a future release.