### PR TITLE
feat(validation-errors): add `overrideErrorMessage` function to `throwValidationErrors`

### DIFF
--- a/apps/playground/src/app/(examples)/hook/deleteuser-action.ts
+++ b/apps/playground/src/app/(examples)/hook/deleteuser-action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ActionError, action } from "@/lib/safe-action";
+import { flattenValidationErrors } from "next-safe-action";
 import { z } from "zod";
 
 const schema = z.object({
@@ -9,15 +10,24 @@ const schema = z.object({
 
 export const deleteUser = action
 	.metadata({ actionName: "deleteUser" })
-	.inputSchema(schema)
-	.action(async ({ parsedInput: { userId } }) => {
-		await new Promise((res) => setTimeout(res, 1000));
+	.inputSchema(schema, { handleValidationErrorsShape: async (ve) => flattenValidationErrors(ve) })
+	.action(
+		async ({ parsedInput: { userId } }) => {
+			await new Promise((res) => setTimeout(res, 1000));
 
-		if (Math.random() > 0.5) {
-			throw new ActionError("Could not delete user!");
+			if (Math.random() > 0.5) {
+				throw new ActionError("Could not delete user!");
+			}
+
+			return {
+				deletedUserId: userId,
+			};
+		},
+		{
+			throwValidationErrors: {
+				async overrideErrorMessage(validationErrors) {
+					return validationErrors.fieldErrors.userId?.[0] ?? "Invalid user ID";
+				},
+			},
 		}
-
-		return {
-			deletedUserId: userId,
-		};
-	});
+	);

--- a/packages/next-safe-action/src/action-builder.ts
+++ b/packages/next-safe-action/src/action-builder.ts
@@ -295,8 +295,21 @@ export function actionBuilder<
 					if (typeof middlewareResult.validationErrors !== "undefined") {
 						// `utils.throwValidationErrors` has higher priority since it's set at the action level.
 						// It overrides the client setting, if set.
-						if (winningBoolean(args.throwValidationErrors, utils?.throwValidationErrors)) {
-							throw new ActionValidationError(middlewareResult.validationErrors as CVE);
+						if (
+							winningBoolean(
+								args.throwValidationErrors,
+								typeof utils?.throwValidationErrors === "undefined" ? undefined : Boolean(utils.throwValidationErrors)
+							)
+						) {
+							const overrideErrorMessageFn =
+								typeof utils?.throwValidationErrors === "object" && utils?.throwValidationErrors.overrideErrorMessage
+									? utils?.throwValidationErrors.overrideErrorMessage
+									: undefined;
+
+							throw new ActionValidationError(
+								middlewareResult.validationErrors as CVE,
+								await overrideErrorMessageFn?.(middlewareResult.validationErrors as CVE)
+							);
 						} else {
 							actionResult.validationErrors = middlewareResult.validationErrors as CVE;
 						}

--- a/packages/next-safe-action/src/index.types.ts
+++ b/packages/next-safe-action/src/index.types.ts
@@ -211,7 +211,7 @@ export type SafeActionUtils<
 	Data,
 > = {
 	throwServerError?: boolean;
-	throwValidationErrors?: boolean;
+	throwValidationErrors?: boolean | { overrideErrorMessage: (validationErrors: CVE) => Promise<string> };
 	onSuccess?: (args: {
 		data?: Data;
 		metadata: MD;

--- a/packages/next-safe-action/src/validation-errors.ts
+++ b/packages/next-safe-action/src/validation-errors.ts
@@ -63,8 +63,8 @@ export class ActionServerValidationError<S extends StandardSchemaV1> extends Err
 // `returnValidationErrors`.
 export class ActionValidationError<CVE> extends Error {
 	public validationErrors: CVE;
-	constructor(validationErrors: CVE) {
-		super("Server Action validation error(s) occurred");
+	constructor(validationErrors: CVE, overriddenErrorMessage?: string) {
+		super(overriddenErrorMessage ?? "Server Action validation error(s) occurred");
 		this.validationErrors = validationErrors;
 	}
 }


### PR DESCRIPTION
Code in this PR adds the ability to override the validation error message, when the `throwValidationErrors` option is used at the action level, using an optional async function called `overrideErrorMessage`, that returns the overridden error message, instead of the default one.
