### PR TITLE
Update bind-arguments.md

### DIFF
--- a/website/docs/define-actions/bind-arguments.md
+++ b/website/docs/define-actions/bind-arguments.md
@@ -22,7 +22,7 @@ const schema = z.object({
 });
 
 export const onboardUser = actionClient
-  .schema(schema)
+  .inputSchema(schema)
   // We can pass a named tuple type here, to get named parameters in the final function.
   // highlight-start
   .bindArgsSchemas<[userId: z.ZodString, age: z.ZodNumber]>([


### PR DESCRIPTION
Changed `schema` to `inputSchema` in documentation about Bind Arguments. As `schema` is deprecated.

# Proposed changes

Put your proposed changes here.

## Related issue(s) or discussion(s)

re #

---

- [ ] I read the [contributing guidelines](https://github.com/TheEdoRan/next-safe-action/blob/next/CONTRIBUTING.md) and followed them before creating this pull request.
